### PR TITLE
feat: 로그아웃 API 및 로그인 성공 시 메인 리다이렉트

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,8 +1,14 @@
-from flask import Flask, render_template, jsonify, request
+from flask import Flask, make_response, render_template, jsonify, request
 from flask_cors import CORS
 from config import Config
 from services import register_user, login_user
-from flask_jwt_extended import JWTManager, create_access_token, set_access_cookies
+from flask_jwt_extended import (
+    JWTManager,
+    create_access_token,
+    jwt_required,
+    set_access_cookies,
+    unset_jwt_cookies,
+)
 from datetime import timedelta
 from pymongo import MongoClient
 from routes.boards import boards_bp
@@ -50,6 +56,15 @@ def api_login():
     set_access_cookies(response, access_token)
 
     return response, statuscode
+
+
+@app.route("/api/auth/logout", methods=["POST"])
+@jwt_required()
+def api_logout():
+    """세션(JWT 쿠키) 무효화. 204 No Content 반환."""
+    response = make_response("", 204)
+    unset_jwt_cookies(response)
+    return response
 
 
 @app.route('/api/auth/register', methods=['POST'])

--- a/static/js/login.js
+++ b/static/js/login.js
@@ -16,8 +16,7 @@ $(document).ready(function () {
       data: JSON.stringify({ username: username, password: password }),
       xhrFields: { withCredentials: true },
       success: function (data) {
-        // 로그인 성공 시 메인(보드 목록) 페이지로 이동
-        // TODO: 메인 페이지 구현 후 경로 수정
+        // 로그인 성공 시 메인(내 칠판 목록) 페이지로 리다이렉트
         window.location.href = "/";
       },
       error: function (xhr) {


### PR DESCRIPTION
# 연관 이슈
-

# 요약
- 로그아웃 API 추가 (POST /api/auth/logout)
- 로그인 성공 시 메인(내 칠판 목록) 페이지로 리다이렉트

# 주요 변경사항
- app.py: POST /api/auth/logout 엔드포인트 추가, unset_jwt_cookies로 쿠키 삭제
- login.js: 로그인 성공 시 "/"로 리다이렉트 (메인 페이지)
