### PR TITLE
Feat/impelement board UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ node_modules
 
 # 로컬 전용 스크립트 (테스트/개발용, git 미포함)
 local/
+
+# 업로드된 이미지
+static/uploads/

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ venv/
 
 # npm
 node_modules
+
+# 로컬 전용 스크립트 (테스트/개발용, git 미포함)
+local/

--- a/app.py
+++ b/app.py
@@ -40,6 +40,12 @@ def home():
     return render_template('login.html')
 
 
+@app.route('/main')
+def main():
+    """로그인 후 내 보드 목록 페이지."""
+    return render_template('main.html')
+
+
 @app.route('/boards/<public_id>')
 def board_page(public_id: str):
     """칠판(화이트보드) 페이지. 보드 및 포스트잇 렌더링."""

--- a/app.py
+++ b/app.py
@@ -21,6 +21,7 @@ CORS(app, supports_credentials=True)
 app.config["JWT_SECRET_KEY"] = Config.SECRET_KEY
 app.config["JWT_TOKEN_LOCATION"] = ['cookies']
 app.config["JWT_ACCESS_TOKEN_EXPIRES"] = timedelta(hours=1)
+app.config["JWT_COOKIE_CSRF_PROTECT"] = False  # fetch/AJAX에서 X-CSRF-TOKEN 미전송 시 POST 401 방지
 jwt = JWTManager(app)
 # !!! 로컬 db 설정에 맞춰 수정 필요
 client = MongoClient("mongodb://localhost:27017")

--- a/app.py
+++ b/app.py
@@ -39,6 +39,12 @@ app.register_blueprint(boards_bp)
 def home():
     return render_template('login.html')
 
+
+@app.route('/boards/<public_id>')
+def board_page(public_id: str):
+    """칠판(화이트보드) 페이지. 보드 및 포스트잇 렌더링."""
+    return render_template('board.html', public_id=public_id)
+
 # 일단은 access token만 httponly로 발급 시간이 된다면 refresh token도 발급
 @app.route('/api/auth/login', methods=['POST'])
 def api_login():

--- a/routes/boards.py
+++ b/routes/boards.py
@@ -9,6 +9,7 @@
 - 포스트잇 수정/이동 (PATCH /api/boards/<public_id>/notes/<note_id>)
 - 포스트잇 삭제 (DELETE /api/boards/<public_id>/notes/<note_id>)
 """
+import os
 import uuid
 
 from bson import ObjectId
@@ -144,11 +145,13 @@ def list_boards():
 # GET /api/boards/<public_id> - 보드 조회
 # ---------------------------------------------------------------------------
 @boards_bp.route("/<public_id>", methods=["GET"])
+@jwt_required(optional=True)
 def get_board(public_id: str):
     """
     보드 조회 API
-    - 인증: 불필요
+    - 인증: 불필요 (로그인 시 current_user_id 포함)
     """
+    current_user_id = _get_current_user_id()
     db = getattr(current_app, "db", None)
     if db is None:
         return jsonify({"error": {"code": "INTERNAL_ERROR", "message": "DB not configured."}}), 500
@@ -168,10 +171,14 @@ def get_board(public_id: str):
 
     image_base_url = current_app.config.get("IMAGE_BASE_URL") or ""
 
-    return jsonify({
+    payload = {
         "board": _serialize_board(board),
         "notes": [_serialize_note(n, image_base_url) for n in notes_list],
-    }), 200
+    }
+    if current_user_id:
+        payload["current_user_id"] = str(current_user_id)
+
+    return jsonify(payload), 200
 
 
 # ---------------------------------------------------------------------------
@@ -361,6 +368,73 @@ def create_note(public_id: str):
 
     image_base_url = current_app.config.get("IMAGE_BASE_URL") or ""
     return jsonify(_serialize_note(note_doc, image_base_url)), 201
+
+
+# ---------------------------------------------------------------------------
+# POST /api/boards/<public_id>/images - 이미지 업로드 (포스트잇용)
+# ---------------------------------------------------------------------------
+ALLOWED_IMAGE_EXT = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
+MAX_IMAGE_SIZE = 3 * 1024 * 1024  # 3MB
+
+
+@boards_bp.route("/<public_id>/images", methods=["POST"])
+@jwt_required(optional=True)
+def upload_image(public_id: str):
+    """포스트잇에 첨부할 이미지 업로드. 인증 필수."""
+    user_id = _get_current_user_id()
+    if not user_id:
+        return jsonify({
+            "error": {"code": "UNAUTHORIZED", "message": "로그인이 필요합니다.", "details": {}}
+        }), 401
+
+    db = getattr(current_app, "db", None)
+    if db is None:
+        return jsonify({"error": {"code": "INTERNAL_ERROR", "message": "DB not configured."}}), 500
+
+    boards = db["boards"]
+    board = boards.find_one({"public_id": public_id})
+    if not board:
+        return jsonify({
+            "error": {"code": "BOARD_NOT_FOUND", "message": "유효하지 않은 보드 링크입니다.", "details": {}}
+        }), 404
+
+    if "file" not in request.files:
+        return jsonify({
+            "error": {"code": "VALIDATION_ERROR", "message": "이미지 파일이 필요합니다.", "details": {}}
+        }), 400
+
+    file = request.files["file"]
+    if not file or not file.filename:
+        return jsonify({
+            "error": {"code": "VALIDATION_ERROR", "message": "파일을 선택해 주세요.", "details": {}}
+        }), 400
+
+    ext = os.path.splitext(file.filename)[1].lower()
+    if ext not in ALLOWED_IMAGE_EXT:
+        return jsonify({
+            "error": {"code": "VALIDATION_ERROR", "message": "jpg, jpeg, png, gif, webp만 업로드 가능합니다.", "details": {}}
+        }), 400
+
+    file.seek(0, os.SEEK_END)
+    size = file.tell()
+    file.seek(0)
+    if size > MAX_IMAGE_SIZE:
+        return jsonify({
+            "error": {"code": "VALIDATION_ERROR", "message": "이미지는 3MB 이하여야 합니다.", "details": {}}
+        }), 400
+
+    base_dir = current_app.static_folder or "static"
+    upload_dir = os.path.join(base_dir, "uploads", "boards", public_id)
+    os.makedirs(upload_dir, exist_ok=True)
+    filename = f"{uuid.uuid4().hex}{ext}"
+    filepath = os.path.join(upload_dir, filename)
+    file.save(filepath)
+
+    image_key = f"uploads/boards/{public_id}/{filename}"
+    base_url = request.url_root.rstrip("/")
+    image_url = f"{base_url}/static/{image_key}"
+
+    return jsonify({"image_key": image_key, "url": image_url}), 201
 
 
 # ---------------------------------------------------------------------------

--- a/routes/boards.py
+++ b/routes/boards.py
@@ -150,6 +150,7 @@ def get_board(public_id: str):
     """
     보드 조회 API
     - 인증: 불필요 (로그인 시 current_user_id 포함)
+    - z_index: sticky_notes에는 서버가 원자적으로 부여한 값만 저장됨 (요구사항 4.4.1)
     """
     current_user_id = _get_current_user_id()
     db = getattr(current_app, "db", None)
@@ -159,15 +160,24 @@ def get_board(public_id: str):
     boards = db["boards"]
     sticky_notes = db["sticky_notes"]
 
-    board = boards.find_one({"public_id": public_id})
+    try:
+        board = boards.find_one({"public_id": str(public_id).strip()})
+    except Exception as e:
+        current_app.logger.exception("get_board find_one: %s", e)
+        return jsonify({"error": {"code": "INTERNAL_ERROR", "message": "보드를 불러올 수 없습니다.", "details": {}}}), 500
+
     if not board:
         return jsonify({
             "error": {"code": "BOARD_NOT_FOUND", "message": "유효하지 않은 보드 링크입니다.", "details": {}}
         }), 404
 
     board_id = board["_id"]
-    notes_cursor = sticky_notes.find({"board_id": board_id}).sort("z_index", 1)
-    notes_list = list(notes_cursor)
+    try:
+        notes_cursor = sticky_notes.find({"board_id": board_id}).sort([("z_index", 1), ("_id", 1)])
+        notes_list = list(notes_cursor)
+    except Exception as e:
+        current_app.logger.exception("get_board notes: %s", e)
+        return jsonify({"error": {"code": "INTERNAL_ERROR", "message": "보드를 불러올 수 없습니다.", "details": {}}}), 500
 
     image_base_url = current_app.config.get("IMAGE_BASE_URL") or ""
 
@@ -337,6 +347,7 @@ def create_note(public_id: str):
     x = int(data.get("x", 0))
     y = int(data.get("y", 0))
 
+    # z_index: 보드 단위 next_z_index로 원자적 부여 (요구사항 4.4.1)
     # 300개 제한: note_count < 300 조건부 $inc
     result = boards.find_one_and_update(
         {"_id": board_id, "note_count": {"$lt": 300}},
@@ -348,7 +359,7 @@ def create_note(public_id: str):
             "error": {"code": "NOTE_LIMIT_EXCEEDED", "message": "보드당 포스트잇 최대 300개 제한을 초과했습니다.", "details": {}}
         }), 403
 
-    z_index = result["next_z_index"]
+    z_index = result.get("next_z_index", 1)
 
     now = utc_now()
     note_doc = {
@@ -373,7 +384,7 @@ def create_note(public_id: str):
 # ---------------------------------------------------------------------------
 # POST /api/boards/<public_id>/images - 이미지 업로드 (포스트잇용)
 # ---------------------------------------------------------------------------
-ALLOWED_IMAGE_EXT = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
+ALLOWED_IMAGE_EXT = {".jpg", ".jpeg", ".png", ".gif"}
 MAX_IMAGE_SIZE = 3 * 1024 * 1024  # 3MB
 
 
@@ -412,7 +423,7 @@ def upload_image(public_id: str):
     ext = os.path.splitext(file.filename)[1].lower()
     if ext not in ALLOWED_IMAGE_EXT:
         return jsonify({
-            "error": {"code": "VALIDATION_ERROR", "message": "jpg, jpeg, png, gif, webp만 업로드 가능합니다.", "details": {}}
+            "error": {"code": "VALIDATION_ERROR", "message": "jpg, jpeg, png, gif만 업로드 가능합니다.", "details": {}}
         }), 400
 
     file.seek(0, os.SEEK_END)

--- a/services.py
+++ b/services.py
@@ -57,3 +57,24 @@ def register_user(data):
     "user_id": user_id,
     "username": username
   }, 201
+
+
+def create_test_user():
+  """
+  UI 없이 테스트 사용자(test/test)를 생성합니다.
+  이미 존재하면 아무 작업도 하지 않습니다.
+  """
+  username = "test"
+  password = "test"
+
+  if db.users.find_one({"username": username}):
+    return {"message": f"사용자 '{username}'가 이미 존재합니다.", "created": False}
+
+  user_id = str(uuid.uuid4())
+  hashed_pw = generate_password_hash(password)
+  db.users.insert_one({
+    "user_id": user_id,
+    "username": username,
+    "password": hashed_pw
+  })
+  return {"message": f"사용자 '{username}' 생성 완료", "created": True}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -193,7 +193,14 @@ div {
   font-size:16px;
 }
 
-.share-btn{
+.board-actions{
+  display:flex;
+  align-items:center;
+  gap:4px;
+}
+
+.share-btn,
+.delete-btn{
   border:0;
   background:transparent;
   cursor:pointer;
@@ -201,9 +208,21 @@ div {
   align-items:center;
   justify-content:center;
   padding:6px;
+  color:#6b7280;
+  transition:color 0.2s;
 }
 
-.share-btn .material-symbols-outlined{
+.share-btn:hover,
+.delete-btn:hover{
+  color:#374151;
+}
+
+.delete-btn:hover{
+  color:#dc2626;
+}
+
+.share-btn .material-symbols-outlined,
+.delete-btn .material-symbols-outlined{
   font-size:22px;
 }
 

--- a/static/js/board.js
+++ b/static/js/board.js
@@ -1,24 +1,118 @@
 $(document).ready(function () {
-  // 공유 버튼 클릭 이벤트
+  const $container = $('#board-container');
+  const publicId = $container.data('public-id');
+  if (!publicId) {
+    console.error('public_id가 없습니다.');
+    return;
+  }
+
+  let board = null;
+  let notes = [];
+
+  function loadBoard() {
+    fetch(`/api/boards/${publicId}`, { credentials: 'include' })
+      .then((res) => {
+        if (!res.ok) {
+          if (res.status === 404) {
+            throw new Error('유효하지 않은 보드 링크입니다.');
+          }
+          throw new Error('보드를 불러올 수 없습니다.');
+        }
+        return res.json();
+      })
+      .then((data) => {
+        board = data.board;
+        notes = data.notes || [];
+        renderBoard();
+        renderNotes();
+      })
+      .catch((err) => {
+        alert(err.message || '보드 로드 실패');
+      });
+  }
+
+  function renderBoard() {
+    $('#board-title').text(board?.title || '보드 제목');
+  }
+
+  function renderNotes() {
+    $container.find('.note').remove();
+    notes.forEach((note) => {
+      const $el = $('<div>')
+        .addClass('note')
+        .css({
+          left: note.x + 'px',
+          top: note.y + 'px',
+          zIndex: note.z_index,
+        })
+        .attr('data-note-id', note.id)
+        .attr('data-version', note.version);
+
+      if (note.image_url) {
+        $el.append($('<img>').attr('src', note.image_url).css({ maxWidth: '100%', display: 'block', marginBottom: 4 }));
+      }
+      $el.append($('<div>').addClass('note-text').text(note.text || ''));
+
+      $container.append($el);
+    });
+  }
+
+  function createNote(x, y, text) {
+    fetch(`/api/boards/${publicId}/notes`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: text || '새 메모', x, y }),
+    })
+      .then(async (res) => {
+        if (res.status === 401) {
+          alert('로그인이 필요합니다. 새 포스트잇을 추가하려면 로그인해 주세요.');
+          return null;
+        }
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          throw new Error(data?.error?.message || '포스트잇 생성에 실패했습니다.');
+        }
+        return res.json();
+      })
+      .then((note) => {
+        if (note) {
+          notes.push(note);
+          renderNotes();
+        }
+      })
+      .catch((err) => {
+        alert(err.message || '포스트잇 생성 실패');
+      });
+  }
+
+  loadBoard();
+
+  // 공유 버튼
   $('#btn-share').on('click', function () {
-    alert('현재 보드의 링크가 클립보드에 복사되었습니다. (구현 필요)');
+    const url = window.location.href;
+    navigator.clipboard
+      .writeText(url)
+      .then(() => alert('현재 보드 링크가 클립보드에 복사되었습니다.'))
+      .catch(() => alert('복사에 실패했습니다. 링크: ' + url));
   });
 
-  // 이미지 추가 버튼 클릭 이벤트
+  // 이미지 추가 버튼
   $('#btn-add-image').on('click', function () {
     console.log('이미지 업로드 모달을 엽니다.');
   });
 
-  // 햄버거 메뉴 클릭 이벤트
+  // 햄버거 메뉴
   $('#btn-menu').on('click', function () {
     console.log('사이드바 메뉴를 엽니다.');
   });
 
-  // 보드 빈 공간을 더블 클릭하면 새 글 작성하기
-  $('#board-container').on('dblclick', function (e) {
-    // 클릭한 위치 (x, y 좌표)
-    const x = e.pageX;
-    const y = e.pageY;
-    console.log(`[${x}, ${y}] 위치에 새 글 쓰기 창을 엽니다.`);
+  // 보드 빈 공간 더블클릭 → 새 포스트잇 생성
+  $container.on('dblclick', function (e) {
+    if ($(e.target).closest('.note').length) return;
+    const x = e.offsetX;
+    const y = e.offsetY;
+    const text = prompt('포스트잇 내용을 입력하세요:', '새 메모') || '새 메모';
+    createNote(x, y, text);
   });
 });

--- a/static/js/board.js
+++ b/static/js/board.js
@@ -102,9 +102,26 @@ $(document).ready(function () {
     console.log('이미지 업로드 모달을 엽니다.');
   });
 
-  // 햄버거 메뉴
-  $('#btn-menu').on('click', function () {
-    console.log('사이드바 메뉴를 엽니다.');
+  // 햄버거 메뉴 → 우측 윙바 오버레이 열기
+  function openWingbar() {
+    $('#wingbar-backdrop, #wingbar').addClass('is-open').attr('aria-hidden', 'false');
+  }
+  function closeWingbar() {
+    $('#wingbar-backdrop, #wingbar').removeClass('is-open').attr('aria-hidden', 'true');
+  }
+
+  $('#btn-menu').on('click', openWingbar);
+  $('#btn-close-wingbar').on('click', closeWingbar);
+  $('#wingbar-backdrop').on('click', closeWingbar);
+
+  // 로그아웃
+  $('#btn-logout').on('click', function () {
+    fetch('/api/auth/logout', { method: 'POST', credentials: 'include' })
+      .then(() => {
+        closeWingbar();
+        window.location.href = '/';
+      })
+      .catch(() => alert('로그아웃에 실패했습니다.'));
   });
 
   // 보드 빈 공간 더블클릭 → 새 포스트잇 생성

--- a/static/js/board.js
+++ b/static/js/board.js
@@ -8,14 +8,15 @@ $(document).ready(function () {
 
   let board = null;
   let notes = [];
+  let currentUserId = null;
+  let imageInsertMode = false;
+  let pendingImagePosition = null;
 
   function loadBoard() {
     fetch(`/api/boards/${publicId}`, { credentials: 'include' })
       .then((res) => {
         if (!res.ok) {
-          if (res.status === 404) {
-            throw new Error('유효하지 않은 보드 링크입니다.');
-          }
+          if (res.status === 404) throw new Error('유효하지 않은 보드 링크입니다.');
           throw new Error('보드를 불러올 수 없습니다.');
         }
         return res.json();
@@ -23,12 +24,42 @@ $(document).ready(function () {
       .then((data) => {
         board = data.board;
         notes = data.notes || [];
+        currentUserId = data.current_user_id || null;
         renderBoard();
         renderNotes();
+        renderWingbarMyNotes();
       })
-      .catch((err) => {
-        alert(err.message || '보드 로드 실패');
-      });
+      .catch((err) => alert(err.message || '보드 로드 실패'));
+  }
+
+  function renderWingbarMyNotes() {
+    const $list = $('#wingbar-my-notes');
+    const $empty = $('#wingbar-my-notes-empty');
+    $list.empty();
+
+    if (!currentUserId) {
+      $empty.text('로그인하면 내가 쓴 메모를 볼 수 있습니다.').show();
+      return;
+    }
+
+    const myNotes = notes.filter((n) => String(n.owner_user_id) === String(currentUserId));
+
+    if (myNotes.length === 0) {
+      $empty.text('쓴 메모가 없습니다.').show();
+      $list.hide();
+      return;
+    }
+
+    $empty.hide();
+    $list.show();
+    myNotes.forEach((note) => {
+      const text = note.text || (note.image_url ? '[이미지]' : '(내용 없음)');
+      const $li = $('<li>')
+        .addClass('wingbar-note-item')
+        .attr('title', text)
+        .text(text.length > 30 ? text.slice(0, 30) + '…' : text);
+      $list.append($li);
+    });
   }
 
   function renderBoard() {
@@ -49,7 +80,11 @@ $(document).ready(function () {
         .attr('data-version', note.version);
 
       if (note.image_url) {
-        $el.append($('<img>').attr('src', note.image_url).css({ maxWidth: '100%', display: 'block', marginBottom: 4 }));
+        $el.append(
+          $('<img>')
+            .attr('src', note.image_url)
+            .css({ maxWidth: '100%', display: 'block', marginBottom: 4, borderRadius: 4 })
+        );
       }
       $el.append($('<div>').addClass('note-text').text(note.text || ''));
 
@@ -57,16 +92,19 @@ $(document).ready(function () {
     });
   }
 
-  function createNote(x, y, text) {
+  function createNote(x, y, text, imageKey) {
+    const body = { text: text || '', x, y };
+    if (imageKey) body.image_key = imageKey;
+
     fetch(`/api/boards/${publicId}/notes`, {
       method: 'POST',
       credentials: 'include',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ text: text || '새 메모', x, y }),
+      body: JSON.stringify(body),
     })
       .then(async (res) => {
         if (res.status === 401) {
-          alert('로그인이 필요합니다. 새 포스트잇을 추가하려면 로그인해 주세요.');
+          alert('로그인이 필요합니다.');
           return null;
         }
         if (!res.ok) {
@@ -79,57 +117,112 @@ $(document).ready(function () {
         if (note) {
           notes.push(note);
           renderNotes();
+          renderWingbarMyNotes();
         }
       })
-      .catch((err) => {
-        alert(err.message || '포스트잇 생성 실패');
-      });
+      .catch((err) => alert(err.message));
   }
 
   loadBoard();
 
-  // 공유 버튼
+  // 공유
   $('#btn-share').on('click', function () {
-    const url = window.location.href;
     navigator.clipboard
-      .writeText(url)
+      .writeText(window.location.href)
       .then(() => alert('현재 보드 링크가 클립보드에 복사되었습니다.'))
-      .catch(() => alert('복사에 실패했습니다. 링크: ' + url));
+      .catch(() => alert('복사에 실패했습니다.'));
   });
 
-  // 이미지 추가 버튼
-  $('#btn-add-image').on('click', function () {
-    console.log('이미지 업로드 모달을 엽니다.');
+  // 이미지 추가 모드
+  $('#btn-add-image').on('click', function (e) {
+    e.stopPropagation();
+    imageInsertMode = !imageInsertMode;
+    $(this).toggleClass('image-mode-active', imageInsertMode);
+    if (!imageInsertMode) closeImageModal();
   });
 
-  // 햄버거 메뉴 → 우측 윙바 오버레이 열기
+  // 윙바
   function openWingbar() {
     $('#wingbar-backdrop, #wingbar').addClass('is-open').attr('aria-hidden', 'false');
   }
   function closeWingbar() {
     $('#wingbar-backdrop, #wingbar').removeClass('is-open').attr('aria-hidden', 'true');
   }
-
   $('#btn-menu').on('click', openWingbar);
   $('#btn-close-wingbar').on('click', closeWingbar);
   $('#wingbar-backdrop').on('click', closeWingbar);
 
-  // 로그아웃
-  $('#btn-logout').on('click', function () {
-    fetch('/api/auth/logout', { method: 'POST', credentials: 'include' })
-      .then(() => {
-        closeWingbar();
-        window.location.href = '/';
-      })
-      .catch(() => alert('로그아웃에 실패했습니다.'));
-  });
-
-  // 보드 빈 공간 더블클릭 → 새 포스트잇 생성
+  // 보드 더블클릭 → 포스트잇 생성
   $container.on('dblclick', function (e) {
     if ($(e.target).closest('.note').length) return;
+    if (imageInsertMode) return;
     const x = e.offsetX;
     const y = e.offsetY;
     const text = prompt('포스트잇 내용을 입력하세요:', '새 메모') || '새 메모';
     createNote(x, y, text);
+  });
+
+  // 보드 클릭 (이미지 모드) → 이미지 삽입 UI
+  $container.on('click', function (e) {
+    if (!imageInsertMode) return;
+    if ($(e.target).closest('.note').length) return;
+    e.preventDefault();
+    e.stopPropagation();
+    pendingImagePosition = { x: e.offsetX, y: e.offsetY };
+    openImageModal();
+  });
+
+  // 이미지 모달
+  function openImageModal() {
+    $('#image-modal').addClass('is-open').attr('aria-hidden', 'false');
+    $('#image-file-input').val('');
+  }
+  function closeImageModal() {
+    $('#image-modal').removeClass('is-open').attr('aria-hidden', 'true');
+    pendingImagePosition = null;
+  }
+
+  $(document).on('click', '.image-modal-backdrop[data-close="true"]', closeImageModal);
+  $('#image-modal-cancel').on('click', closeImageModal);
+
+  $('#image-modal-confirm').on('click', function () {
+    const input = document.getElementById('image-file-input');
+    if (!input.files || !input.files[0]) {
+      alert('이미지 파일을 선택해 주세요.');
+      return;
+    }
+    if (!pendingImagePosition) {
+      closeImageModal();
+      return;
+    }
+    const { x, y } = pendingImagePosition;
+    const formData = new FormData();
+    formData.append('file', input.files[0]);
+
+    fetch(`/api/boards/${publicId}/images`, {
+      method: 'POST',
+      credentials: 'include',
+      body: formData,
+    })
+      .then(async (res) => {
+        if (res.status === 401) {
+          alert('로그인이 필요합니다.');
+          return null;
+        }
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          throw new Error(data?.error?.message || '이미지 업로드에 실패했습니다.');
+        }
+        return res.json();
+      })
+      .then((data) => {
+        if (data) {
+          createNote(x, y, '', data.image_key);
+          closeImageModal();
+          imageInsertMode = false;
+          $('#btn-add-image').removeClass('image-mode-active');
+        }
+      })
+      .catch((err) => alert(err.message));
   });
 });

--- a/static/js/board.js
+++ b/static/js/board.js
@@ -14,12 +14,13 @@ $(document).ready(function () {
 
   function loadBoard() {
     fetch(`/api/boards/${publicId}`, { credentials: 'include' })
-      .then((res) => {
+      .then(async (res) => {
+        const data = await res.json().catch(() => ({}));
         if (!res.ok) {
           if (res.status === 404) throw new Error('유효하지 않은 보드 링크입니다.');
-          throw new Error('보드를 불러올 수 없습니다.');
+          throw new Error(data?.error?.message || '보드를 불러올 수 없습니다.');
         }
-        return res.json();
+        return data;
       })
       .then((data) => {
         board = data.board;
@@ -56,14 +57,58 @@ $(document).ready(function () {
       const text = note.text || (note.image_url ? '[이미지]' : '(내용 없음)');
       const $li = $('<li>')
         .addClass('wingbar-note-item')
+        .attr('data-note-id', note.id)
         .attr('title', text)
         .text(text.length > 30 ? text.slice(0, 30) + '…' : text);
       $list.append($li);
     });
   }
 
+  function highlightNote(noteId) {
+    $container.find('.note').removeClass('is-highlighted');
+    $('#wingbar-my-notes .wingbar-note-item').removeClass('is-active');
+    if (noteId) {
+      $container.find('.note[data-note-id="' + noteId + '"]').addClass('is-highlighted');
+      $('#wingbar-my-notes .wingbar-note-item[data-note-id="' + noteId + '"]').addClass('is-active');
+    }
+  }
+
   function renderBoard() {
     $('#board-title').text(board?.title || '보드 제목');
+  }
+
+  function updateNotePosition(noteId, x, y, version) {
+    const note = notes.find((n) => n.id === noteId);
+    if (!note) return;
+    fetch(`/api/boards/${publicId}/notes/${noteId}`, {
+      method: 'PATCH',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ version: note.version, x: Math.round(x), y: Math.round(y) }),
+    })
+      .then(async (res) => {
+        if (res.status === 401) {
+          alert('로그인이 필요합니다.');
+          return null;
+        }
+        if (res.status === 403 || res.status === 409) {
+          const data = await res.json().catch(() => ({}));
+          loadBoard();
+          alert(data?.error?.message || '이동할 수 없습니다. 최신 상태로 새로고침했습니다.');
+          return null;
+        }
+        if (!res.ok) return null;
+        return res.json();
+      })
+      .then((updated) => {
+        if (updated) {
+          const idx = notes.findIndex((n) => n.id === noteId);
+          if (idx >= 0) notes[idx] = updated;
+          renderNotes();
+          renderWingbarMyNotes();
+        }
+      })
+      .catch(() => {});
   }
 
   function renderNotes() {
@@ -72,21 +117,24 @@ $(document).ready(function () {
       const $el = $('<div>')
         .addClass('note')
         .css({
-          left: note.x + 'px',
-          top: note.y + 'px',
-          zIndex: note.z_index,
+          left: (note.x ?? 0) + 'px',
+          top: (note.y ?? 0) + 'px',
+          zIndex: note.z_index ?? 0,
         })
         .attr('data-note-id', note.id)
         .attr('data-version', note.version);
 
+      $el.append($('<div>').addClass('note-drag-handle'));
+      const $body = $('<div>').addClass('note-body');
       if (note.image_url) {
-        $el.append(
+        $body.append(
           $('<img>')
             .attr('src', note.image_url)
             .css({ maxWidth: '100%', display: 'block', marginBottom: 4, borderRadius: 4 })
         );
       }
-      $el.append($('<div>').addClass('note-text').text(note.text || ''));
+      $body.append($('<div>').addClass('note-text').text(note.text || ''));
+      $el.append($body);
 
       $container.append($el);
     });
@@ -149,20 +197,291 @@ $(document).ready(function () {
     $('#wingbar-backdrop, #wingbar').removeClass('is-open').attr('aria-hidden', 'true');
   }
   $('#btn-menu').on('click', openWingbar);
-  $('#btn-close-wingbar').on('click', closeWingbar);
-  $('#wingbar-backdrop').on('click', closeWingbar);
+  $('#btn-close-wingbar').on('click', function () {
+    closeWingbar();
+    highlightNote(null);
+  });
+  $('#wingbar-backdrop').on('click', function () {
+    closeWingbar();
+    highlightNote(null);
+  });
 
-  // 보드 더블클릭 → 포스트잇 생성
-  $container.on('dblclick', function (e) {
-    if ($(e.target).closest('.note').length) return;
-    if (imageInsertMode) return;
-    const x = e.offsetX;
-    const y = e.offsetY;
-    const text = prompt('포스트잇 내용을 입력하세요:', '새 메모') || '새 메모';
+  $(document).on('click', '#wingbar-my-notes .wingbar-note-item', function () {
+    const noteId = $(this).attr('data-note-id');
+    highlightNote(noteId);
+    openNoteDetailModal(noteId);
+  });
+
+  let pendingNotePosition = null; // 더블클릭 시 생성 위치 저장 (null이면 + 버튼, center 사용)
+  function closeNoteModal() {
+    $('#note-modal').removeClass('is-open').attr('aria-hidden', 'true');
+    pendingNotePosition = null;
+  }
+
+  function openNoteModal(atPosition) {
+    pendingNotePosition = atPosition; // {x,y} 또는 null
+    $('#note-modal').addClass('is-open').attr('aria-hidden', 'false');
+    $('#note-modal-text').val('').focus();
+  }
+
+  $('#btn-add-note').on('click', function () {
+    openNoteModal(null);
+  });
+  $(document).on('click', '.note-modal-backdrop[data-close="true"]', closeNoteModal);
+  $('#note-modal-cancel').on('click', closeNoteModal);
+
+  $(document).on('click', '#note-modal-confirm', function () {
+    const text = String($('#note-modal-text').val() || '').trim() || '새 메모';
+    const pos = pendingNotePosition;
+    closeNoteModal();
+    const rect = $container[0].getBoundingClientRect();
+    let x, y;
+    if (pos) {
+      x = Math.max(20, pos.x);
+      y = Math.max(20, pos.y);
+    } else {
+      x = Math.max(20, Math.floor(window.innerWidth / 2 - rect.left - 80));
+      y = Math.max(20, Math.floor(window.innerHeight / 2 - rect.top - 50));
+    }
     createNote(x, y, text);
   });
 
-  // 보드 클릭 (이미지 모드) → 이미지 삽입 UI
+  // 보드 빈 곳 더블클릭 → 새 포스트잇 모달 열기
+  // dblclick이 보드 영역에서 미발생하는 경우가 있어, mousedown 기반 수동 감지 추가
+  const DBLCLICK_DELAY = 400;
+  const DBLCLICK_MOVE = 5;
+  let lastBoardMousedown = { t: 0, x: 0, y: 0 };
+
+  function tryOpenNoteModalAt(clientX, clientY) {
+    if (imageInsertMode) return;
+    const rect = $container[0].getBoundingClientRect();
+    if (clientX < rect.left || clientX > rect.right || clientY < rect.top || clientY > rect.bottom) return false;
+    const x = Math.max(20, clientX - rect.left);
+    const y = Math.max(20, clientY - rect.top);
+    openNoteModal({ x, y });
+    return true;
+  }
+
+  document.addEventListener(
+    'mousedown',
+    function (e) {
+      if (e.button !== 0) return;
+      if ($(e.target).closest('.note, .note-modal, .note-detail-modal, .image-modal, .wingbar').length) return;
+      const rect = $container[0].getBoundingClientRect();
+      if (e.clientX < rect.left || e.clientX > rect.right || e.clientY < rect.top || e.clientY > rect.bottom) return;
+      const now = Date.now();
+      if (now - lastBoardMousedown.t <= DBLCLICK_DELAY && Math.abs(e.clientX - lastBoardMousedown.x) <= DBLCLICK_MOVE && Math.abs(e.clientY - lastBoardMousedown.y) <= DBLCLICK_MOVE) {
+        e.preventDefault();
+        e.stopPropagation();
+        lastBoardMousedown = { t: 0, x: 0, y: 0 };
+        tryOpenNoteModalAt(e.clientX, e.clientY);
+        return;
+      }
+      lastBoardMousedown = { t: now, x: e.clientX, y: e.clientY };
+    },
+    true
+  );
+
+  document.addEventListener(
+    'dblclick',
+    function (e) {
+      if ($(e.target).closest('.note').length) return;
+      if ($(e.target).closest('.note-modal, .note-detail-modal, .image-modal, .wingbar').length) return;
+      if (tryOpenNoteModalAt(e.clientX, e.clientY)) {
+        lastBoardMousedown = { t: 0, x: 0, y: 0 };
+      }
+    },
+    true
+  );
+
+  // 포스트잇 더블클릭 → 수정 모달
+  $container.on('dblclick', '.note', function (e) {
+    if (imageInsertMode) return;
+    e.stopPropagation();
+    const noteId = $(e.currentTarget).attr('data-note-id');
+    if (noteId) openNoteDetailModal(noteId);
+  });
+
+  // 포스트잇 드래그로 이동 (이동 8px 이상일 때만 드래그, 그 전에는 텍스트 선택 가능)
+  const DRAG_THRESHOLD = 8;
+  let dragging = { $el: null, noteId: null, startX: 0, startY: 0, startLeft: 0, startTop: 0, active: false };
+
+  // 포스트잇 상세 모달 (요구사항 4.4)
+  let detailModalNoteId = null;
+  let detailModalOriginalZ = null;
+
+  function openNoteDetailModal(noteId) {
+    const note = notes.find((n) => n.id === noteId);
+    if (!note) return;
+    detailModalNoteId = noteId;
+    const $noteEl = $container.find('.note[data-note-id="' + noteId + '"]');
+    if ($noteEl.length) {
+      detailModalOriginalZ = $noteEl.css('z-index');
+      $noteEl.css('z-index', 9999);
+    }
+    $('#note-detail-text').text(note.text || '(내용 없음)');
+    const $img = $('#note-detail-image');
+    if (note.image_url) {
+      $img.attr('src', note.image_url).show();
+    } else {
+      $img.hide();
+    }
+    const isOwner = !!(currentUserId && String(note.owner_user_id) === String(currentUserId));
+    if (isOwner) {
+      $('#note-detail-edit, #note-detail-delete').show();
+    } else {
+      $('#note-detail-edit, #note-detail-delete').hide();
+    }
+    $('#note-detail-view').show();
+    $('#note-detail-edit-view').hide();
+    $('#note-detail-modal').addClass('is-open').attr('aria-hidden', 'false');
+  }
+
+  function closeNoteDetailModal() {
+    if (detailModalNoteId) {
+      const $noteEl = $container.find('.note[data-note-id="' + detailModalNoteId + '"]');
+      if ($noteEl.length && detailModalOriginalZ != null) {
+        $noteEl.css('z-index', detailModalOriginalZ);
+      }
+    }
+    detailModalNoteId = null;
+    detailModalOriginalZ = null;
+    $('#note-detail-modal').removeClass('is-open').attr('aria-hidden', 'true');
+  }
+
+  $(document).on('click', '.note-detail-backdrop[data-close="true"]', closeNoteDetailModal);
+  $('#note-detail-close').on('click', closeNoteDetailModal);
+
+  $('#note-detail-edit').on('click', function () {
+    const note = notes.find((n) => n.id === detailModalNoteId);
+    if (!note) return;
+    $('#note-detail-edit-textarea').val(note.text || '');
+    $('#note-detail-view').hide();
+    $('#note-detail-edit-view').show();
+  });
+
+  $('#note-detail-cancel-edit').on('click', function () {
+    $('#note-detail-edit-view').hide();
+    $('#note-detail-view').show();
+  });
+
+  $('#note-detail-save').on('click', function () {
+    const note = notes.find((n) => n.id === detailModalNoteId);
+    if (!note) return;
+    const text = $('#note-detail-edit-textarea').val() || '';
+    fetch(`/api/boards/${publicId}/notes/${detailModalNoteId}`, {
+      method: 'PATCH',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ version: note.version, text }),
+    })
+      .then(async (res) => {
+        if (res.status === 401) {
+          alert('로그인이 필요합니다.');
+          return null;
+        }
+        if (res.status === 403 || res.status === 409) {
+          const data = await res.json().catch(() => ({}));
+          loadBoard();
+          alert(data?.error?.message || '수정할 수 없습니다. 최신 상태로 새로고침했습니다.');
+          closeNoteDetailModal();
+          return null;
+        }
+        if (!res.ok) return null;
+        return res.json();
+      })
+      .then((updated) => {
+        if (updated) {
+          const idx = notes.findIndex((n) => n.id === detailModalNoteId);
+          if (idx >= 0) notes[idx] = updated;
+          renderNotes();
+          renderWingbarMyNotes();
+          closeNoteDetailModal();
+        }
+      })
+      .catch(() => {});
+  });
+
+  $('#note-detail-delete').on('click', function () {
+    if (!confirm('이 포스트잇을 삭제할까요?')) return;
+    const noteId = detailModalNoteId;
+    if (!noteId) return;
+    fetch(`/api/boards/${publicId}/notes/${noteId}`, { method: 'DELETE', credentials: 'include' })
+      .then(async (res) => {
+        if (res.status === 401) {
+          alert('로그인이 필요합니다.');
+          return null;
+        }
+        if (res.status === 403 || res.status === 404) {
+          const data = await res.json().catch(() => ({}));
+          alert(data?.error?.message || '삭제할 수 없습니다.');
+          return null;
+        }
+        return res.ok;
+      })
+      .then((ok) => {
+        if (ok) {
+          notes = notes.filter((n) => n.id !== noteId);
+          renderNotes();
+          renderWingbarMyNotes();
+          closeNoteDetailModal();
+        }
+      })
+      .catch(() => {});
+  });
+
+  $(document).on('selectstart', function (e) {
+    if (dragging.$el) e.preventDefault();
+  });
+
+  $container.on('mousedown', '.note', function (e) {
+    if (imageInsertMode) return;
+    if (e.button !== 0) return;
+    if (!currentUserId) return; // 익명 사용자는 메모 이동 불가
+    if ($(e.target).closest('.note-text').length) return;
+    e.preventDefault();
+    window.getSelection().removeAllRanges();
+    document.body.classList.add('select-none');
+    const $note = $(this);
+    const noteId = $note.attr('data-note-id');
+    if (!noteId) return;
+    dragging = {
+      $el: $note,
+      noteId: noteId,
+      startX: e.clientX,
+      startY: e.clientY,
+      startLeft: parseFloat($note.css('left')) || 0,
+      startTop: parseFloat($note.css('top')) || 0,
+      active: false,
+    };
+  });
+
+  $(document)
+    .on('mousemove', function (e) {
+      if (!dragging.$el) return;
+      const dx = e.clientX - dragging.startX;
+      const dy = e.clientY - dragging.startY;
+      if (!dragging.active && (Math.abs(dx) > DRAG_THRESHOLD || Math.abs(dy) > DRAG_THRESHOLD)) {
+        dragging.active = true;
+      }
+      if (!dragging.active) return;
+      dragging.$el.css({
+        left: Math.max(0, dragging.startLeft + dx) + 'px',
+        top: Math.max(0, dragging.startTop + dy) + 'px',
+      });
+    })
+    .on('mouseup', function () {
+      if (!dragging.$el) return;
+      document.body.classList.remove('select-none');
+      if (dragging.active) {
+        const left = parseFloat(dragging.$el.css('left')) || 0;
+        const top = parseFloat(dragging.$el.css('top')) || 0;
+        updateNotePosition(dragging.noteId, left, top);
+      }
+      dragging = { $el: null, noteId: null, startX: 0, startY: 0, startLeft: 0, startTop: 0, active: false };
+    });
+
+  // 보드 클릭 (이미지 모드만) → 이미지 삽입 UI
   $container.on('click', function (e) {
     if (!imageInsertMode) return;
     if ($(e.target).closest('.note').length) return;

--- a/static/js/login.js
+++ b/static/js/login.js
@@ -17,7 +17,7 @@ $(document).ready(function () {
       xhrFields: { withCredentials: true },
       success: function (data) {
         // 로그인 성공 시 메인(내 칠판 목록) 페이지로 리다이렉트
-        window.location.href = "/";
+        window.location.href = "/main";
       },
       error: function (xhr) {
         const msg = xhr.responseJSON?.error || "로그인에 실패했습니다.";

--- a/templates/board.html
+++ b/templates/board.html
@@ -55,6 +55,164 @@
       .wingbar.is-open {
         transform: translateX(0);
       }
+      .wingbar-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 20px 24px;
+        border-bottom: 1px solid #e5e7eb;
+      }
+      .wingbar-title {
+        font-size: 18px;
+        font-weight: 600;
+        color: #111827;
+      }
+      .wingbar-close {
+        width: 32px;
+        height: 32px;
+        border: none;
+        background: transparent;
+        font-size: 24px;
+        line-height: 1;
+        color: #6b7280;
+        cursor: pointer;
+        border-radius: 6px;
+        transition: background 0.2s, color 0.2s;
+      }
+      .wingbar-close:hover {
+        background: #f3f4f6;
+        color: #111827;
+      }
+      .wingbar-body {
+        padding: 16px;
+      }
+      .wingbar-item {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 14px 16px;
+        color: #374151;
+        font-size: 15px;
+        text-decoration: none;
+        border-radius: 8px;
+        transition: background 0.2s, color 0.2s;
+      }
+      .wingbar-item:hover {
+        background: #f3f4f6;
+        color: #111827;
+      }
+      .wingbar-item-icon {
+        font-size: 18px;
+        opacity: 0.8;
+      }
+      .wingbar-section {
+        margin-top: 20px;
+        padding-top: 16px;
+        border-top: 1px solid #e5e7eb;
+      }
+      .wingbar-section-title {
+        margin: 0 0 12px;
+        font-size: 13px;
+        font-weight: 600;
+        color: #6b7280;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+      }
+      .wingbar-note-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        max-height: 200px;
+        overflow-y: auto;
+      }
+      .wingbar-note-item {
+        padding: 10px 12px;
+        margin-bottom: 4px;
+        font-size: 13px;
+        color: #374151;
+        background: #f9fafb;
+        border-radius: 6px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .wingbar-note-item:last-child {
+        margin-bottom: 0;
+      }
+      .wingbar-empty {
+        margin: 0;
+        font-size: 13px;
+        color: #9ca3af;
+      }
+      /* 이미지 모달 */
+      .image-modal {
+        position: fixed;
+        inset: 0;
+        z-index: 300;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        opacity: 0;
+        visibility: hidden;
+        transition: opacity 0.2s, visibility 0.2s;
+      }
+      .image-modal.is-open {
+        opacity: 1;
+        visibility: visible;
+      }
+      .image-modal-backdrop {
+        position: absolute;
+        inset: 0;
+        background: rgba(0,0,0,0.4);
+      }
+      .image-modal-panel {
+        position: relative;
+        width: 90%;
+        max-width: 400px;
+        padding: 24px;
+        background: white;
+        border-radius: 12px;
+        box-shadow: 0 10px 40px rgba(0,0,0,0.2);
+      }
+      .image-modal-title {
+        margin: 0 0 16px;
+        font-size: 18px;
+        font-weight: 600;
+        color: #111827;
+      }
+      .image-modal-input {
+        display: block;
+        width: 100%;
+        margin-bottom: 20px;
+        padding: 10px;
+        border: 1px solid #d1d5db;
+        border-radius: 8px;
+      }
+      .image-modal-actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: 8px;
+      }
+      .image-modal-btn {
+        padding: 10px 20px;
+        border: none;
+        border-radius: 8px;
+        font-size: 14px;
+        font-weight: 500;
+        cursor: pointer;
+      }
+      .image-modal-btn-secondary {
+        background: #f3f4f6;
+        color: #374151;
+      }
+      .image-modal-btn-primary {
+        background: #05D182;
+        color: white;
+      }
+      #btn-add-image.image-mode-active {
+        outline: 2px solid #05D182;
+        outline-offset: 2px;
+      }
     </style>
     <link
       href="{{ url_for('static', filename='css/output.css') }}"
@@ -81,7 +239,7 @@
           />
         </button>
 
-        <button id="btn-add-image" class="hover:scale-110 transition transform">
+        <button id="btn-add-image" class="hover:scale-110 transition transform" title="이미지 추가 모드 (클릭 후 보드에서 위치 선택)">
           <img
             src="{{ url_for('static', filename='icons/image.svg') }}"
             alt="이미지 추가"
@@ -105,22 +263,38 @@
       data-public-id="{{ public_id }}"
     ></main>
 
-    <!-- 우측 윙바 오버레이 -->
+    <!-- 우측 윙바 -->
     <div class="wingbar-backdrop" id="wingbar-backdrop" aria-hidden="true"></div>
     <aside class="wingbar" id="wingbar" aria-hidden="true">
-      <div class="flex justify-between items-center p-6 border-b border-gray-200">
-        <h2 class="text-lg font-semibold text-gray-700">메뉴</h2>
-        <button type="button" id="btn-close-wingbar" class="p-1 rounded hover:bg-gray-100 transition" aria-label="메뉴 닫기">
-          <svg class="w-6 h-6 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-          </svg>
-        </button>
+      <div class="wingbar-header">
+        <span class="wingbar-title">메뉴</span>
+        <button type="button" id="btn-close-wingbar" class="wingbar-close" aria-label="닫기">×</button>
       </div>
-      <nav class="p-4 space-y-1">
-        <a href="/" class="block px-4 py-3 rounded-lg text-gray-700 hover:bg-gray-100 transition">내 보드 목록</a>
-        <button type="button" id="btn-logout" class="block w-full text-left px-4 py-3 rounded-lg text-gray-700 hover:bg-gray-100 transition">로그아웃</button>
-      </nav>
+      <div class="wingbar-body">
+        <a href="/main" class="wingbar-item">
+          <span class="wingbar-item-icon">≡</span>
+          <span>내 보드 목록</span>
+        </a>
+        <div class="wingbar-section">
+          <h3 class="wingbar-section-title">내가 쓴 메모</h3>
+          <ul class="wingbar-note-list" id="wingbar-my-notes"></ul>
+          <p class="wingbar-empty" id="wingbar-my-notes-empty" style="display:none;">쓴 메모가 없습니다.</p>
+        </div>
+      </div>
     </aside>
+
+    <!-- 이미지 삽입 모달 -->
+    <div class="image-modal" id="image-modal" aria-hidden="true">
+      <div class="image-modal-backdrop" data-close="true"></div>
+      <div class="image-modal-panel">
+        <h3 class="image-modal-title">이미지 추가</h3>
+        <input type="file" id="image-file-input" accept="image/jpeg,image/png,image/gif,image/webp" class="image-modal-input" />
+        <div class="image-modal-actions">
+          <button type="button" id="image-modal-cancel" class="image-modal-btn image-modal-btn-secondary">취소</button>
+          <button type="button" id="image-modal-confirm" class="image-modal-btn image-modal-btn-primary">추가</button>
+        </div>
+      </div>
+    </div>
 
     <script src="{{ url_for('static', filename='js/board.js') }}"></script>
   </body>

--- a/templates/board.html
+++ b/templates/board.html
@@ -26,6 +26,35 @@
         overflow: hidden;
         cursor: move;
       }
+      .wingbar-backdrop {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.3);
+        z-index: 200;
+        opacity: 0;
+        visibility: hidden;
+        transition: opacity 0.2s, visibility 0.2s;
+      }
+      .wingbar-backdrop.is-open {
+        opacity: 1;
+        visibility: visible;
+      }
+      .wingbar {
+        position: fixed;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        width: 280px;
+        max-width: 90vw;
+        background: white;
+        box-shadow: -4px 0 20px rgba(0, 0, 0, 0.15);
+        z-index: 201;
+        transform: translateX(100%);
+        transition: transform 0.25s ease-out;
+      }
+      .wingbar.is-open {
+        transform: translateX(0);
+      }
     </style>
     <link
       href="{{ url_for('static', filename='css/output.css') }}"
@@ -75,6 +104,23 @@
       class="min-w-full min-h-[calc(100vh-6rem)] bg-logo relative z-10 pt-24"
       data-public-id="{{ public_id }}"
     ></main>
+
+    <!-- 우측 윙바 오버레이 -->
+    <div class="wingbar-backdrop" id="wingbar-backdrop" aria-hidden="true"></div>
+    <aside class="wingbar" id="wingbar" aria-hidden="true">
+      <div class="flex justify-between items-center p-6 border-b border-gray-200">
+        <h2 class="text-lg font-semibold text-gray-700">메뉴</h2>
+        <button type="button" id="btn-close-wingbar" class="p-1 rounded hover:bg-gray-100 transition" aria-label="메뉴 닫기">
+          <svg class="w-6 h-6 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+      <nav class="p-4 space-y-1">
+        <a href="/" class="block px-4 py-3 rounded-lg text-gray-700 hover:bg-gray-100 transition">내 보드 목록</a>
+        <button type="button" id="btn-logout" class="block w-full text-left px-4 py-3 rounded-lg text-gray-700 hover:bg-gray-100 transition">로그아웃</button>
+      </nav>
+    </aside>
 
     <script src="{{ url_for('static', filename='js/board.js') }}"></script>
   </body>

--- a/templates/board.html
+++ b/templates/board.html
@@ -7,11 +7,24 @@
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <style>
       .bg-logo {
-        background-image: url(../static/icons/Jungle_by\ KRAFTON_Logo_G.png);
+        background-image: url('{{ url_for("static", filename="icons/Jungle_by KRAFTON_Logo_G.png") }}');
         background-repeat: no-repeat;
         background-position: center;
         background-size: 300px;
         opacity: 0.5;
+      }
+      .note {
+        position: absolute;
+        min-width: 120px;
+        min-height: 100px;
+        max-width: 200px;
+        padding: 8px;
+        background: #fef08a;
+        box-shadow: 2px 2px 6px rgba(0,0,0,0.2);
+        border-radius: 4px;
+        word-wrap: break-word;
+        overflow: hidden;
+        cursor: move;
       }
     </style>
     <link
@@ -59,7 +72,8 @@
 
     <main
       id="board-container"
-      class="w-480 h-270 bg-logo relative z-10 pt-24"
+      class="min-w-full min-h-[calc(100vh-6rem)] bg-logo relative z-10 pt-24"
+      data-public-id="{{ public_id }}"
     ></main>
 
     <script src="{{ url_for('static', filename='js/board.js') }}"></script>

--- a/templates/board.html
+++ b/templates/board.html
@@ -7,25 +7,76 @@
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <style>
       .bg-logo {
+        position: relative;
+      }
+      .bg-logo::before {
+        content: '';
+        position: absolute;
+        inset: 0;
         background-image: url('{{ url_for("static", filename="icons/Jungle_by KRAFTON_Logo_G.png") }}');
         background-repeat: no-repeat;
         background-position: center;
         background-size: 300px;
         opacity: 0.5;
+        pointer-events: none;
+        z-index: 0;
       }
       .note {
         position: absolute;
-        min-width: 120px;
-        min-height: 100px;
-        max-width: 200px;
-        padding: 8px;
-        background: #fef08a;
-        box-shadow: 2px 2px 6px rgba(0,0,0,0.2);
+        width: fit-content;
+        max-width: 320px;
+        background: transparent;
+        pointer-events: auto;
+        z-index: 1;
+        user-select: none;
+        -webkit-user-select: none;
+        box-shadow: none;
         border-radius: 4px;
         word-wrap: break-word;
-        overflow: hidden;
+        overflow-wrap: break-word;
+      }
+      .note-drag-handle {
+        height: 20px;
+        cursor: move;
+        flex-shrink: 0;
+      }
+      .note-drag-handle::before {
+        content: '⋮⋮';
+        font-size: 12px;
+        color: rgba(0,0,0,0.3);
+        padding-left: 4px;
+      }
+      .note-body {
+        padding: 4px 12px 8px;
+        overflow: visible;
         cursor: move;
       }
+      .note-text {
+        white-space: pre-wrap;
+        word-break: break-word;
+        user-select: text;
+        -webkit-user-select: text;
+        cursor: text;
+      }
+      .note-body img {
+        max-width: 100%;
+        max-height: 160px;
+        object-fit: contain;
+      }
+      .note.is-highlighted {
+        background: rgba(254, 240, 138, 0.6);
+        box-shadow: 0 0 0 2px rgba(251, 191, 36, 0.8);
+      }
+      .wingbar-note-item.is-active {
+        background: #e5e7eb;
+      }
+      .header-pointer-through {
+        pointer-events: none;
+      }
+      .header-pointer-through .header-clickable {
+        pointer-events: auto;
+      }
+      .select-none { user-select: none; -webkit-user-select: none; }
       .wingbar-backdrop {
         position: fixed;
         inset: 0;
@@ -33,11 +84,13 @@
         z-index: 200;
         opacity: 0;
         visibility: hidden;
+        pointer-events: none;
         transition: opacity 0.2s, visibility 0.2s;
       }
       .wingbar-backdrop.is-open {
         opacity: 1;
         visibility: visible;
+        pointer-events: auto;
       }
       .wingbar {
         position: fixed;
@@ -51,11 +104,14 @@
         z-index: 201;
         transform: translateX(100%);
         transition: transform 0.25s ease-out;
+        display: flex;
+        flex-direction: column;
       }
       .wingbar.is-open {
         transform: translateX(0);
       }
       .wingbar-header {
+        flex-shrink: 0;
         display: flex;
         align-items: center;
         justify-content: space-between;
@@ -85,8 +141,13 @@
       }
       .wingbar-body {
         padding: 16px;
+        flex: 1;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
       }
       .wingbar-item {
+        flex-shrink: 0;
         display: flex;
         align-items: center;
         gap: 12px;
@@ -109,8 +170,13 @@
         margin-top: 20px;
         padding-top: 16px;
         border-top: 1px solid #e5e7eb;
+        flex: 1;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
       }
       .wingbar-section-title {
+        flex-shrink: 0;
         margin: 0 0 12px;
         font-size: 13px;
         font-weight: 600;
@@ -122,7 +188,8 @@
         list-style: none;
         margin: 0;
         padding: 0;
-        max-height: 200px;
+        flex: 1;
+        min-height: calc(100vh - 130px);
         overflow-y: auto;
       }
       .wingbar-note-item {
@@ -154,11 +221,13 @@
         justify-content: center;
         opacity: 0;
         visibility: hidden;
+        pointer-events: none;
         transition: opacity 0.2s, visibility 0.2s;
       }
       .image-modal.is-open {
         opacity: 1;
         visibility: visible;
+        pointer-events: auto;
       }
       .image-modal-backdrop {
         position: absolute;
@@ -213,6 +282,147 @@
         outline: 2px solid #05D182;
         outline-offset: 2px;
       }
+      /* 새 포스트잇 모달 */
+      .note-modal {
+        position: fixed;
+        inset: 0;
+        z-index: 300;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        opacity: 0;
+        visibility: hidden;
+        pointer-events: none;
+        transition: opacity 0.2s, visibility 0.2s;
+      }
+      .note-modal.is-open {
+        opacity: 1;
+        visibility: visible;
+        pointer-events: auto;
+      }
+      .note-modal-backdrop {
+        position: absolute;
+        inset: 0;
+        background: rgba(0,0,0,0.4);
+      }
+      .note-modal-panel {
+        position: relative;
+        width: 90%;
+        max-width: 420px;
+        padding: 24px;
+        background: white;
+        border-radius: 12px;
+        box-shadow: 0 10px 40px rgba(0,0,0,0.2);
+      }
+      .note-modal-title {
+        margin: 0 0 8px;
+        font-size: 18px;
+        font-weight: 600;
+        color: #111827;
+      }
+      .note-modal-hint {
+        margin: 0 0 16px;
+        font-size: 13px;
+        color: #6b7280;
+      }
+      .note-modal-textarea {
+        display: block;
+        width: 100%;
+        margin-bottom: 20px;
+        padding: 12px;
+        border: 1px solid #d1d5db;
+        border-radius: 8px;
+        font-size: 14px;
+        resize: vertical;
+        outline: none;
+      }
+      .note-modal-textarea:focus {
+        border-color: #05D182;
+        box-shadow: 0 0 0 2px rgba(5,209,130,0.2);
+      }
+      .note-modal-actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: 8px;
+      }
+      .note-modal-btn {
+        padding: 10px 20px;
+        border: none;
+        border-radius: 8px;
+        font-size: 14px;
+        font-weight: 500;
+        cursor: pointer;
+      }
+      .note-modal-btn-secondary {
+        background: #f3f4f6;
+        color: #374151;
+      }
+      .note-modal-btn-primary {
+        background: #05D182;
+        color: white;
+      }
+      /* 포스트잇 상세 모달 (요구사항 4.4) */
+      .note-detail-modal {
+        position: fixed;
+        inset: 0;
+        z-index: 350;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        opacity: 0;
+        visibility: hidden;
+        pointer-events: none;
+        transition: opacity 0.2s, visibility 0.2s;
+      }
+      .note-detail-modal.is-open {
+        opacity: 1;
+        visibility: visible;
+        pointer-events: auto;
+      }
+      .note-detail-backdrop {
+        position: absolute;
+        inset: 0;
+        background: rgba(0,0,0,0.5);
+      }
+      .note-detail-panel {
+        position: relative;
+        width: 90%;
+        max-width: 600px;
+        max-height: 90vh;
+        padding: 24px;
+        background: white;
+        border-radius: 12px;
+        box-shadow: 0 10px 40px rgba(0,0,0,0.2);
+        overflow-y: auto;
+      }
+      .note-detail-text {
+        margin: 0 0 16px;
+        font-size: 15px;
+        line-height: 1.6;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+      .note-detail-image {
+        max-width: 90vw;
+        max-height: 80vh;
+        display: block;
+        margin: 0 auto 16px;
+      }
+      .note-detail-actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: 8px;
+        margin-top: 16px;
+      }
+      .note-detail-edit-textarea {
+        width: 100%;
+        min-height: 120px;
+        padding: 12px;
+        border: 1px solid #d1d5db;
+        border-radius: 8px;
+        font-size: 14px;
+        margin-bottom: 16px;
+      }
     </style>
     <link
       href="{{ url_for('static', filename='css/output.css') }}"
@@ -221,16 +431,20 @@
   </head>
   <body class="bg-white w-full h-screen overflow-auto relative">
     <header
-      class="flex justify-between items-center p-6 md:px-10 md:py-8 fixed top-0 w-full z-50"
+      class="flex justify-between items-center p-6 md:px-10 md:py-8 fixed top-0 w-full z-50 header-pointer-through"
     >
       <h1
-        class="text-3xl md:text-4xl font-bold text-gray-500 tracking-wide cursor-pointer hover:text-gray-700 transition"
+        class="text-3xl md:text-4xl font-bold text-gray-500 tracking-wide cursor-pointer hover:text-gray-700 transition header-clickable"
         id="board-title"
       >
         보드 제목
       </h1>
 
-      <div class="flex items-center space-x-4 md:space-x-6">
+      <div class="flex items-center space-x-4 md:space-x-6 header-clickable">
+        <button id="btn-add-note" class="flex items-center gap-2 px-4 py-2 rounded-lg bg-amber-400 hover:bg-amber-500 text-amber-900 font-medium transition shadow-sm" title="새 포스트잇">
+          <span>+</span>
+          <span class="hidden sm:inline">새 포스트잇</span>
+        </button>
         <button id="btn-share" class="hover:scale-110 transition transform">
           <img
             src="{{ url_for('static', filename='icons/share.svg') }}"
@@ -257,11 +471,15 @@
       </div>
     </header>
 
+    <!-- 보드를 전체 뷰포트에 고정해 헤더 영역과 동일하게 클릭을 받도록 함 -->
     <main
       id="board-container"
-      class="min-w-full min-h-[calc(100vh-6rem)] bg-logo relative z-10 pt-24"
+      class="fixed inset-0 min-w-full min-h-full bg-logo z-10 pt-24"
+      style="overflow:auto;"
       data-public-id="{{ public_id }}"
-    ></main>
+    >
+      <div id="board-click-layer" style="position:absolute;inset:0;z-index:0;cursor:default;"></div>
+    </main>
 
     <!-- 우측 윙바 -->
     <div class="wingbar-backdrop" id="wingbar-backdrop" aria-hidden="true"></div>
@@ -283,12 +501,49 @@
       </div>
     </aside>
 
+    <!-- 새 포스트잇 모달 -->
+    <div class="note-modal" id="note-modal" aria-hidden="true">
+      <div class="note-modal-backdrop" data-close="true"></div>
+      <div class="note-modal-panel">
+        <h3 class="note-modal-title">새 포스트잇</h3>
+        <p class="note-modal-hint">내용을 입력하고 추가를 누르면 보드 가운데 근처에 포스트잇이 생성됩니다.</p>
+        <textarea id="note-modal-text" class="note-modal-textarea" placeholder="메모 내용을 입력하세요..." rows="4"></textarea>
+        <div class="note-modal-actions">
+          <button type="button" id="note-modal-cancel" class="note-modal-btn note-modal-btn-secondary">취소</button>
+          <button type="button" id="note-modal-confirm" class="note-modal-btn note-modal-btn-primary">추가</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- 포스트잇 상세 모달 (요구사항 4.4) -->
+    <div class="note-detail-modal" id="note-detail-modal" aria-hidden="true">
+      <div class="note-detail-backdrop" data-close="true"></div>
+      <div class="note-detail-panel">
+        <div id="note-detail-view">
+          <p class="note-detail-text" id="note-detail-text"></p>
+          <img class="note-detail-image" id="note-detail-image" alt="" style="display:none;" />
+          <div class="note-detail-actions" id="note-detail-actions">
+            <button type="button" id="note-detail-edit" class="note-modal-btn note-modal-btn-secondary" style="display:none;">수정</button>
+            <button type="button" id="note-detail-delete" class="note-modal-btn note-modal-btn-secondary" style="display:none;">삭제</button>
+            <button type="button" id="note-detail-close" class="note-modal-btn note-modal-btn-primary">닫기</button>
+          </div>
+        </div>
+        <div id="note-detail-edit-view" style="display:none;">
+          <textarea id="note-detail-edit-textarea" class="note-detail-edit-textarea" placeholder="메모 내용"></textarea>
+          <div class="note-detail-actions">
+            <button type="button" id="note-detail-save" class="note-modal-btn note-modal-btn-primary">저장</button>
+            <button type="button" id="note-detail-cancel-edit" class="note-modal-btn note-modal-btn-secondary">취소</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <!-- 이미지 삽입 모달 -->
     <div class="image-modal" id="image-modal" aria-hidden="true">
       <div class="image-modal-backdrop" data-close="true"></div>
       <div class="image-modal-panel">
         <h3 class="image-modal-title">이미지 추가</h3>
-        <input type="file" id="image-file-input" accept="image/jpeg,image/png,image/gif,image/webp" class="image-modal-input" />
+        <input type="file" id="image-file-input" accept="image/jpeg,image/png,image/gif" class="image-modal-input" />
         <div class="image-modal-actions">
           <button type="button" id="image-modal-cancel" class="image-modal-btn image-modal-btn-secondary">취소</button>
           <button type="button" id="image-modal-confirm" class="image-modal-btn image-modal-btn-primary">추가</button>

--- a/templates/main.html
+++ b/templates/main.html
@@ -7,7 +7,7 @@
     <script src="https://code.jquery.com/jquery-3.5.1.min.js"
         integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
     <title>내가 만든 보드</title>
-    <link href="../static/css/main.css" rel="stylesheet" />
+    <link href="{{ url_for('static', filename='css/main.css') }}" rel="stylesheet" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" />
 </head>
 
@@ -50,112 +50,7 @@
         <main class="content">
             <h1>내가 만든 보드</h1>
             <div class="content-body">
-                <!-- 리스트 영역 -->
-                <!-- 보드 이름, 공유 버튼 -->
-                <ul class="board-list">
-                    <li class="board-item">
-                        <span class="board-title">보드 이름</span>
-                        <button class="share-btn" type="button" aria-label="공유하기">
-                            <span class="material-symbols-outlined">share</span>
-                        </button>
-                    </li>
-
-                    <li class="board-item">
-                        <span class="board-title">보드 이름</span>
-                        <button class="share-btn" type="button" aria-label="공유하기">
-                            <span class="material-symbols-outlined">share</span>
-                        </button>
-                    </li>
-
-                    <li class="board-item">
-                        <span class="board-title">보드 이름</span>
-                        <button class="share-btn" type="button" aria-label="공유하기">
-                            <span class="material-symbols-outlined">share</span>
-                        </button>
-                    </li>
-
-                    <li class="board-item">
-                        <span class="board-title">보드 이름</span>
-                        <button class="share-btn" type="button" aria-label="공유하기">
-                            <span class="material-symbols-outlined">share</span>
-                        </button>
-                    </li>
-
-                    <li class="board-item">
-                        <span class="board-title">보드 이름</span>
-                        <button class="share-btn" type="button" aria-label="공유하기">
-                            <span class="material-symbols-outlined">share</span>
-                        </button>
-                    </li>
-                    <li class="board-item">
-                        <span class="board-title">보드 이름</span>
-                        <button class="share-btn" type="button" aria-label="공유하기">
-                            <span class="material-symbols-outlined">share</span>
-                        </button>
-                    </li>
-
-                    <li class="board-item">
-                        <span class="board-title">보드 이름</span>
-                        <button class="share-btn" type="button" aria-label="공유하기">
-                            <span class="material-symbols-outlined">share</span>
-                        </button>
-                    </li>
-
-                    <li class="board-item">
-                        <span class="board-title">보드 이름</span>
-                        <button class="share-btn" type="button" aria-label="공유하기">
-                            <span class="material-symbols-outlined">share</span>
-                        </button>
-                    </li>
-
-                    <li class="board-item">
-                        <span class="board-title">보드 이름</span>
-                        <button class="share-btn" type="button" aria-label="공유하기">
-                            <span class="material-symbols-outlined">share</span>
-                        </button>
-                    </li>
-
-                    <li class="board-item">
-                        <span class="board-title">보드 이름</span>
-                        <button class="share-btn" type="button" aria-label="공유하기">
-                            <span class="material-symbols-outlined">share</span>
-                        </button>
-                    </li>
-                    <li class="board-item">
-                        <span class="board-title">보드 이름</span>
-                        <button class="share-btn" type="button" aria-label="공유하기">
-                            <span class="material-symbols-outlined">share</span>
-                        </button>
-                    </li>
-
-                    <li class="board-item">
-                        <span class="board-title">보드 이름</span>
-                        <button class="share-btn" type="button" aria-label="공유하기">
-                            <span class="material-symbols-outlined">share</span>
-                        </button>
-                    </li>
-
-                    <li class="board-item">
-                        <span class="board-title">보드 이름</span>
-                        <button class="share-btn" type="button" aria-label="공유하기">
-                            <span class="material-symbols-outlined">share</span>
-                        </button>
-                    </li>
-
-                    <li class="board-item">
-                        <span class="board-title">보드 이름</span>
-                        <button class="share-btn" type="button" aria-label="공유하기">
-                            <span class="material-symbols-outlined">share</span>
-                        </button>
-                    </li>
-
-                    <li class="board-item">
-                        <span class="board-title">보드 이름</span>
-                        <button class="share-btn" type="button" aria-label="공유하기">
-                            <span class="material-symbols-outlined">share</span>
-                        </button>
-                    </li>
-                </ul>
+                <ul class="board-list" id="board-list"></ul>
             </div>
             <button class="fab" aria-label="보드 추가">+</button>
         </main>
@@ -199,6 +94,8 @@
         const fab = document.querySelector(".fab");
         const modalCloseBtn = document.getElementById("modalCloseBtn");
         const boardNameInput = document.getElementById("boardNameInput");
+        const createBoardBtn = document.getElementById("createBoardBtn");
+        const boardList = document.getElementById("board-list");
 
         function openModal() {
             modal.classList.add("is-open");
@@ -215,15 +112,102 @@
         fab.addEventListener("click", openModal);
         modalCloseBtn.addEventListener("click", closeModal);
 
-        // 바깥(오버레이) 클릭 시 닫기
         modal.addEventListener("click", (e) => {
             if (e.target.dataset.close === "true") closeModal();
         });
 
-        // ESC로 닫기
         document.addEventListener("keydown", (e) => {
             if (e.key === "Escape" && modal.classList.contains("is-open")) closeModal();
         });
+
+        // 보드 목록 로드
+        function loadBoards() {
+            fetch("/api/boards", { credentials: "include" })
+                .then((r) => {
+                    if (r.status === 401) {
+                        window.location.href = "/";
+                        return null;
+                    }
+                    if (!r.ok) throw new Error("보드 목록을 불러올 수 없습니다.");
+                    return r.json();
+                })
+                .then((data) => {
+                    if (!data) return;
+                    renderBoards(data.boards || []);
+                })
+                .catch((err) => {
+                    boardList.innerHTML = "<li class='board-item'>" + err.message + "</li>";
+                });
+        }
+
+        function renderBoards(boards) {
+            if (boards.length === 0) {
+                boardList.innerHTML = "<li class='board-item'><span class='board-title'>보드가 없습니다. + 버튼으로 새 보드를 만드세요.</span></li>";
+                return;
+            }
+            boardList.innerHTML = boards
+                .map(
+                    (b) =>
+                        '<li class="board-item">' +
+                        '<a href="/boards/' + b.public_id + '" class="board-title">' + escapeHtml(b.title || "제목 없음") + "</a>" +
+                        '<button class="share-btn" type="button" aria-label="공유하기" data-url="' + escapeHtml(window.location.origin + "/boards/" + b.public_id) + '">' +
+                        '<span class="material-symbols-outlined">share</span></button></li>'
+                )
+                .join("");
+            boardList.querySelectorAll(".share-btn").forEach((el) => {
+                el.addEventListener("click", (e) => {
+                    e.preventDefault();
+                    const url = el.dataset.url;
+                    navigator.clipboard.writeText(url).then(() => alert("보드 링크가 클립보드에 복사되었습니다.")).catch(() => alert("복사 실패: " + url));
+                });
+            });
+        }
+
+        function escapeHtml(s) {
+            const div = document.createElement("div");
+            div.textContent = s;
+            return div.innerHTML;
+        }
+
+        // 보드 만들기
+        createBoardBtn.addEventListener("click", () => {
+            const title = boardNameInput.value.trim() || "새 보드";
+            createBoardBtn.disabled = true;
+            fetch("/api/boards", {
+                method: "POST",
+                credentials: "include",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ title }),
+            })
+                .then((r) => {
+                    if (r.status === 401) {
+                        alert("로그인이 필요합니다.");
+                        return null;
+                    }
+                    if (!r.ok) throw new Error("보드 생성에 실패했습니다.");
+                    return r.json();
+                })
+                .then((data) => {
+                    createBoardBtn.disabled = false;
+                    if (data) {
+                        closeModal();
+                        window.location.href = "/boards/" + data.public_id;
+                    }
+                })
+                .catch((err) => {
+                    createBoardBtn.disabled = false;
+                    alert(err.message);
+                });
+        });
+
+        // 로그아웃
+        document.querySelector(".logout").addEventListener("click", () => {
+            fetch("/api/auth/logout", { method: "POST", credentials: "include" })
+                .then(() => { window.location.href = "/"; })
+                .catch(() => alert("로그아웃에 실패했습니다."));
+        });
+
+        loadBoards();
     </script>
 
 

--- a/templates/main.html
+++ b/templates/main.html
@@ -148,10 +148,14 @@
             boardList.innerHTML = boards
                 .map(
                     (b) =>
-                        '<li class="board-item">' +
+                        '<li class="board-item" data-public-id="' + escapeHtml(b.public_id) + '">' +
                         '<a href="/boards/' + b.public_id + '" class="board-title">' + escapeHtml(b.title || "제목 없음") + "</a>" +
+                        '<div class="board-actions">' +
                         '<button class="share-btn" type="button" aria-label="공유하기" data-url="' + escapeHtml(window.location.origin + "/boards/" + b.public_id) + '">' +
-                        '<span class="material-symbols-outlined">share</span></button></li>'
+                        '<span class="material-symbols-outlined">share</span></button>' +
+                        '<button class="delete-btn" type="button" aria-label="삭제" data-public-id="' + escapeHtml(b.public_id) + '" data-title="' + escapeHtml(b.title || "제목 없음") + '">' +
+                        '<span class="material-symbols-outlined">delete</span></button>' +
+                        '</div></li>'
                 )
                 .join("");
             boardList.querySelectorAll(".share-btn").forEach((el) => {
@@ -161,12 +165,44 @@
                     navigator.clipboard.writeText(url).then(() => alert("보드 링크가 클립보드에 복사되었습니다.")).catch(() => alert("복사 실패: " + url));
                 });
             });
+            boardList.querySelectorAll(".delete-btn").forEach((el) => {
+                el.addEventListener("click", (e) => {
+                    e.preventDefault();
+                    const publicId = el.dataset.publicId;
+                    const title = el.dataset.title;
+                    if (!confirm('"' + title + '" 보드를 삭제하시겠습니까?')) return;
+                    deleteBoard(publicId, el.closest(".board-item"));
+                });
+            });
         }
 
         function escapeHtml(s) {
             const div = document.createElement("div");
             div.textContent = s;
             return div.innerHTML;
+        }
+
+        function deleteBoard(publicId, listItem) {
+            fetch("/api/boards/" + publicId, {
+                method: "DELETE",
+                credentials: "include",
+            })
+                .then((r) => {
+                    if (r.status === 401) {
+                        alert("로그인이 필요합니다.");
+                        return;
+                    }
+                    if (r.status === 403) {
+                        alert("보드 생성자만 삭제할 수 있습니다.");
+                        return;
+                    }
+                    if (!r.ok) throw new Error("삭제에 실패했습니다.");
+                    listItem.remove();
+                    if (boardList.querySelectorAll(".board-item").length === 0) {
+                        boardList.innerHTML = "<li class='board-item'><span class='board-title'>보드가 없습니다. + 버튼으로 새 보드를 만드세요.</span></li>";
+                    }
+                })
+                .catch((err) => alert(err.message));
         }
 
         // 보드 만들기


### PR DESCRIPTION
# 연관 이슈
-

# 요약
- 보드 및 포스트잇 UI 구현

# 주요 변경사항
1. 프론트엔드 (board.js, board.html)
- 보드 더블클릭으로 새 메모 생성: 보드 빈 공간을 더블클릭하면 새 포스트잇 모달이 열립니다.
- 전체 영역에서 동작: board-container를 position: fixed; inset: 0으로 변경해 화면 전체에서 더블클릭이 동작합니다.
- 새 메모 모달 통일: + 버튼과 더블클릭이 같은 모달을 사용합니다. 취소 시에는 새 메모가 생성되지 않습니다.
- 익명 사용자 제한: 수정/삭제 버튼을 숨기고, 메모 이동(드래그)을 비활성화했습니다.
- 버튼 표시 수정: jQuery toggle() 대신 .show()/.hide()로 변경해 익명 사용자에서 수정/삭제 버튼이 번갈아 보이는 현상을 수정했습니다.
- 닫힌 오버레이 클릭 통과: 닫힌 모달/윙바 백드롭에 pointer-events: none을 적용해 클릭이 아래 보드로 전달되도록 했습니다.

2. 백엔드 (routes/boards.py)
- 보드 조회 안정화: 예외 처리 추가, public_id trim 처리, 노트 정렬에 z_index, _id 사용
- 노트 생성: z_index 원자 할당 로직 보완 및 기본값 처리
- 이미지 업로드: webp 확장자 제거, 에러 메시지 수정
