### PR TITLE
Feat/38 board UI improvement

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,6 +41,12 @@ def home():
     return render_template('login.html')
 
 
+@app.route('/register')
+def register_page():
+    """회원가입 페이지."""
+    return render_template('register.html')
+
+
 @app.route('/main')
 def main():
     """로그인 후 내 보드 목록 페이지."""

--- a/app.py
+++ b/app.py
@@ -1,13 +1,15 @@
-from flask import Flask, make_response, render_template, jsonify, request
+from flask import Flask, make_response, render_template, jsonify, request, redirect
 from flask_cors import CORS
 from config import Config
 from services import register_user, login_user
 from flask_jwt_extended import (
     JWTManager,
     create_access_token,
+    get_jwt_identity,
     jwt_required,
     set_access_cookies,
     unset_jwt_cookies,
+    verify_jwt_in_request,
 )
 from datetime import timedelta
 from pymongo import MongoClient
@@ -38,6 +40,12 @@ app.register_blueprint(boards_bp)
 
 @app.route('/')
 def home():
+    try:
+        verify_jwt_in_request(optional=True)
+        if get_jwt_identity():
+            return redirect('/main')
+    except Exception:
+        pass
     return render_template('login.html')
 
 

--- a/routes/boards.py
+++ b/routes/boards.py
@@ -192,14 +192,15 @@ def get_board(public_id: str):
 
 
 # ---------------------------------------------------------------------------
-# PATCH /api/boards/<public_id> - public_id 변경
+# PATCH /api/boards/<public_id> - public_id 또는 title 변경
 # ---------------------------------------------------------------------------
 @boards_bp.route("/<public_id>", methods=["PATCH"])
 @jwt_required(optional=True)
 def update_board(public_id: str):
     """
-    보드 public_id 변경 API
-    - 인증: 필수 (보드 생성자만)
+    보드 수정 API
+    - public_id: 보드 링크 변경 (보드 생성자만)
+    - title: 보드 제목 변경 (보드 생성자만)
     """
     user_id = _get_current_user_id()
     if not user_id:
@@ -213,10 +214,7 @@ def update_board(public_id: str):
 
     data = request.get_json(silent=True) or {}
     new_public_id = data.get("public_id")
-    if not new_public_id:
-        return jsonify({
-            "error": {"code": "VALIDATION_ERROR", "message": "public_id가 필요합니다.", "details": {}}
-        }), 422
+    new_title = data.get("title")
 
     boards = db["boards"]
     board = boards.find_one({"public_id": public_id})
@@ -230,14 +228,22 @@ def update_board(public_id: str):
             "error": {"code": "FORBIDDEN", "message": "보드 생성자만 수정할 수 있습니다.", "details": {}}
         }), 403
 
-    boards.update_one(
-        {"_id": board["_id"]},
-        {"$set": {"public_id": new_public_id, "updated_at": utc_now()}}
-    )
+    if new_title is not None:
+        boards.update_one(
+            {"_id": board["_id"]},
+            {"$set": {"title": str(new_title).strip() or "", "updated_at": utc_now()}}
+        )
+        board["title"] = str(new_title).strip() or ""
 
-    # TODO: board_invalidated WebSocket broadcast (기존 room)
+    if new_public_id:
+        boards.update_one(
+            {"_id": board["_id"]},
+            {"$set": {"public_id": new_public_id, "updated_at": utc_now()}}
+        )
+        board["public_id"] = new_public_id
 
-    return jsonify({"public_id": new_public_id}), 200
+    result = {"title": board.get("title", ""), "public_id": board.get("public_id")}
+    return jsonify(result), 200
 
 
 # ---------------------------------------------------------------------------

--- a/static/js/board.js
+++ b/static/js/board.js
@@ -82,7 +82,54 @@ $(document).ready(function () {
     } else {
       $('#btn-login').hide();
     }
+    const isBoardOwner = !!(currentUserId && board && String(board.owner_user_id) === String(currentUserId));
+    if (isBoardOwner) {
+      $('#board-title').css('cursor', 'pointer');
+    } else {
+      $('#board-title').css('cursor', 'default');
+    }
   }
+
+  function openBoardTitleModal() {
+    $('#board-title-input').val(board?.title || '');
+    $('#board-title-modal').addClass('is-open').attr('aria-hidden', 'false');
+    setTimeout(() => $('#board-title-input').focus(), 100);
+  }
+  function closeBoardTitleModal() {
+    $('#board-title-modal').removeClass('is-open').attr('aria-hidden', 'true');
+  }
+  $(document).on('click', '#board-title-modal .note-modal-backdrop[data-close="true"]', closeBoardTitleModal);
+  $('#board-title-cancel').on('click', closeBoardTitleModal);
+  $('#board-title-save').on('click', function () {
+    const title = String($('#board-title-input').val() || '').trim();
+    fetch(`/api/boards/${publicId}`, {
+      method: 'PATCH',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: title || '' }),
+    })
+      .then(async (res) => {
+        if (res.status === 401) { showLoginRequiredModal(); return null; }
+        if (res.status === 403) { alert('보드 생성자만 제목을 수정할 수 있습니다.'); return null; }
+        if (!res.ok) { const d = await res.json().catch(() => ({})); throw new Error(d?.error?.message || '수정 실패'); }
+        return res.json();
+      })
+      .then((data) => {
+        if (data && data.title !== undefined) {
+          board = board || {};
+          board.title = data.title;
+          $('#board-title').text(data.title || '보드 제목');
+          closeBoardTitleModal();
+          alert('보드 제목이 저장되었습니다.');
+        }
+      })
+      .catch((err) => alert(err.message));
+  });
+
+  $(document).on('click', '#board-title', function () {
+    const isBoardOwner = !!(currentUserId && board && String(board.owner_user_id) === String(currentUserId));
+    if (isBoardOwner) openBoardTitleModal();
+  });
 
   function updateNotePosition(noteId, x, y, version) {
     const note = notes.find((n) => n.id === noteId);

--- a/static/js/board.js
+++ b/static/js/board.js
@@ -266,7 +266,8 @@ $(document).ready(function () {
     openNoteDetailModal(noteId);
   });
 
-  let pendingNotePosition = null; // 더블클릭 시 생성 위치 저장 (null이면 + 버튼, center 사용)
+  let pendingNotePosition = null; // 더블클릭 시 생성 위치 저장 (null이면 + 버튼 경로)
+  let lastMousePos = null; // 마지막 마우스 위치 (키보드로 추가 시 폴백용)
 
   function showLoginRequiredModal() {
     $('#login-required-modal').addClass('is-open').attr('aria-hidden', 'false');
@@ -288,13 +289,17 @@ $(document).ready(function () {
     $('#note-modal-text').val('').focus();
   }
 
+  $(document).on('mousemove', function (e) {
+    lastMousePos = { clientX: e.clientX, clientY: e.clientY };
+  });
+
   $('#btn-add-note').on('click', function () {
     openNoteModal(null);
   });
   $(document).on('click', '.note-modal-backdrop[data-close="true"]', closeNoteModal);
   $('#note-modal-cancel').on('click', closeNoteModal);
 
-  $(document).on('click', '#note-modal-confirm', function () {
+  $(document).on('click', '#note-modal-confirm', function (e) {
     const text = String($('#note-modal-text').val() || '').trim() || '새 메모';
     const pos = pendingNotePosition;
     closeNoteModal();
@@ -304,8 +309,29 @@ $(document).ready(function () {
       x = Math.max(20, pos.x);
       y = Math.max(20, pos.y);
     } else {
-      x = Math.max(20, Math.floor(window.innerWidth / 2 - rect.left - 80));
-      y = Math.max(20, Math.floor(window.innerHeight / 2 - rect.top - 50));
+      const getPosFromCoords = (cx, cy) => {
+        if (cx === 0 && cy === 0) return null;
+        const mx = cx - rect.left;
+        const my = cy - rect.top;
+        return mx >= 0 && mx <= rect.width && my >= 0 && my <= rect.height
+          ? { x: Math.max(20, mx), y: Math.max(20, my) }
+          : null;
+      };
+      const isKeyboardTrigger = e.detail === 0;
+      const fromClick = !isKeyboardTrigger ? getPosFromCoords(e.clientX, e.clientY) : null;
+      const fromLastMouse = lastMousePos ? getPosFromCoords(lastMousePos.clientX, lastMousePos.clientY) : null;
+      const centerX = Math.max(20, Math.floor(window.innerWidth / 2 - rect.left - 80));
+      const centerY = Math.max(20, Math.floor(window.innerHeight / 2 - rect.top - 50));
+      if (fromClick) {
+        x = fromClick.x;
+        y = fromClick.y;
+      } else if (fromLastMouse) {
+        x = fromLastMouse.x;
+        y = fromLastMouse.y;
+      } else {
+        x = centerX;
+        y = centerY;
+      }
     }
     createNote(x, y, text);
   });

--- a/static/js/board.js
+++ b/static/js/board.js
@@ -404,6 +404,7 @@ $(document).ready(function () {
     const note = notes.find((n) => n.id === noteId);
     if (!note) return;
     detailModalNoteId = noteId;
+    highlightNote(noteId);
     const $noteEl = $container.find('.note[data-note-id="' + noteId + '"]');
     if ($noteEl.length) {
       detailModalOriginalZ = $noteEl.css('z-index');
@@ -436,11 +437,21 @@ $(document).ready(function () {
     }
     detailModalNoteId = null;
     detailModalOriginalZ = null;
+    highlightNote(null);
     $('#note-detail-modal').removeClass('is-open').attr('aria-hidden', 'true');
   }
 
   $(document).on('click', '.note-detail-backdrop[data-close="true"]', closeNoteDetailModal);
   $('#note-detail-close').on('click', closeNoteDetailModal);
+
+  $(document).on('keydown', function (e) {
+    if (e.key !== 'Delete' && e.key !== 'Backspace') return;
+    if (!$('#note-detail-modal').hasClass('is-open')) return;
+    if ($('#note-detail-edit-view').is(':visible')) return;
+    if (!$('#note-detail-delete').is(':visible')) return;
+    e.preventDefault();
+    $('#note-detail-delete').trigger('click');
+  });
 
   $('#note-detail-edit').on('click', function () {
     const note = notes.find((n) => n.id === detailModalNoteId);

--- a/static/js/board.js
+++ b/static/js/board.js
@@ -5,6 +5,7 @@ $(document).ready(function () {
     console.error('public_id가 없습니다.');
     return;
   }
+  $('#login-required-goto').attr('href', '/?next=' + encodeURIComponent('/boards/' + publicId));
 
   let board = null;
   let notes = [];
@@ -88,7 +89,7 @@ $(document).ready(function () {
     })
       .then(async (res) => {
         if (res.status === 401) {
-          alert('로그인이 필요합니다.');
+          showLoginRequiredModal();
           return null;
         }
         if (res.status === 403 || res.status === 409) {
@@ -152,7 +153,7 @@ $(document).ready(function () {
     })
       .then(async (res) => {
         if (res.status === 401) {
-          alert('로그인이 필요합니다.');
+          showLoginRequiredModal();
           return null;
         }
         if (!res.ok) {
@@ -213,6 +214,16 @@ $(document).ready(function () {
   });
 
   let pendingNotePosition = null; // 더블클릭 시 생성 위치 저장 (null이면 + 버튼, center 사용)
+
+  function showLoginRequiredModal() {
+    $('#login-required-modal').addClass('is-open').attr('aria-hidden', 'false');
+  }
+  function closeLoginRequiredModal() {
+    $('#login-required-modal').removeClass('is-open').attr('aria-hidden', 'true');
+  }
+  $(document).on('click', '#login-required-modal .note-modal-backdrop[data-close="true"]', closeLoginRequiredModal);
+  $('#login-required-close').on('click', closeLoginRequiredModal);
+
   function closeNoteModal() {
     $('#note-modal').removeClass('is-open').attr('aria-hidden', 'true');
     pendingNotePosition = null;
@@ -377,7 +388,7 @@ $(document).ready(function () {
     })
       .then(async (res) => {
         if (res.status === 401) {
-          alert('로그인이 필요합니다.');
+          showLoginRequiredModal();
           return null;
         }
         if (res.status === 403 || res.status === 409) {
@@ -409,7 +420,7 @@ $(document).ready(function () {
     fetch(`/api/boards/${publicId}/notes/${noteId}`, { method: 'DELETE', credentials: 'include' })
       .then(async (res) => {
         if (res.status === 401) {
-          alert('로그인이 필요합니다.');
+          showLoginRequiredModal();
           return null;
         }
         if (res.status === 403 || res.status === 404) {
@@ -525,7 +536,7 @@ $(document).ready(function () {
     })
       .then(async (res) => {
         if (res.status === 401) {
-          alert('로그인이 필요합니다.');
+          showLoginRequiredModal();
           return null;
         }
         if (!res.ok) {

--- a/static/js/board.js
+++ b/static/js/board.js
@@ -6,6 +6,7 @@ $(document).ready(function () {
     return;
   }
   $('#login-required-goto').attr('href', '/?next=' + encodeURIComponent('/boards/' + publicId));
+  $('#btn-login').attr('href', '/?next=' + encodeURIComponent('/boards/' + publicId));
 
   let board = null;
   let notes = [];
@@ -76,6 +77,11 @@ $(document).ready(function () {
 
   function renderBoard() {
     $('#board-title').text(board?.title || '보드 제목');
+    if (!currentUserId) {
+      $('#btn-login').show();
+    } else {
+      $('#btn-login').hide();
+    }
   }
 
   function updateNotePosition(noteId, x, y, version) {

--- a/static/js/login.js
+++ b/static/js/login.js
@@ -16,8 +16,11 @@ $(document).ready(function () {
       data: JSON.stringify({ username: username, password: password }),
       xhrFields: { withCredentials: true },
       success: function (data) {
-        // 로그인 성공 시 메인(내 칠판 목록) 페이지로 리다이렉트
-        window.location.href = "/main";
+        // 로그인 성공 시 next 파라미터가 있으면 해당 페이지로, 없으면 메인으로 리다이렉트
+        const params = new URLSearchParams(window.location.search);
+        const next = params.get('next');
+        const target = next && next.startsWith('/') && !next.startsWith('//') ? next : '/main';
+        window.location.href = target;
       },
       error: function (xhr) {
         const msg = xhr.responseJSON?.error || "로그인에 실패했습니다.";

--- a/templates/board.html
+++ b/templates/board.html
@@ -441,6 +441,7 @@
       </h1>
 
       <div class="flex items-center space-x-4 md:space-x-6 header-clickable">
+        <a href="#" id="btn-login" class="flex items-center gap-2 px-4 py-2 rounded-lg font-medium transition shadow-sm no-underline" style="display:none; background-color:#05D182; color:white; text-decoration:none;" title="로그인">로그인</a>
         <button id="btn-add-note" class="flex items-center gap-2 px-4 py-2 rounded-lg bg-amber-400 hover:bg-amber-500 text-amber-900 font-medium transition shadow-sm" title="새 포스트잇">
           <span>+</span>
           <span class="hidden sm:inline">새 포스트잇</span>

--- a/templates/board.html
+++ b/templates/board.html
@@ -538,6 +538,19 @@
       </div>
     </div>
 
+    <!-- 로그인 필요 모달 (미로그인 시 포스트잇 등 쓰기 작업 시 표시) -->
+    <div class="note-modal" id="login-required-modal" aria-hidden="true">
+      <div class="note-modal-backdrop" data-close="true"></div>
+      <div class="note-modal-panel">
+        <h3 class="note-modal-title">로그인해주세요</h3>
+        <p class="note-modal-hint">이 기능을 사용하려면 로그인이 필요합니다.</p>
+        <div class="note-modal-actions">
+          <button type="button" id="login-required-close" class="note-modal-btn note-modal-btn-secondary">취소</button>
+          <a href="/" class="note-modal-btn note-modal-btn-primary" id="login-required-goto">로그인 페이지로</a>
+        </div>
+      </div>
+    </div>
+
     <!-- 이미지 삽입 모달 -->
     <div class="image-modal" id="image-modal" aria-hidden="true">
       <div class="image-modal-backdrop" data-close="true"></div>

--- a/templates/board.html
+++ b/templates/board.html
@@ -520,7 +520,7 @@
       <div class="note-modal-backdrop" data-close="true"></div>
       <div class="note-modal-panel">
         <h3 class="note-modal-title">새 포스트잇</h3>
-        <p class="note-modal-hint">내용을 입력하고 추가를 누르면 보드 가운데 근처에 포스트잇이 생성됩니다.</p>
+        <p class="note-modal-hint">내용을 입력하고 추가를 누르면 마우스 커서 위치에 포스트잇이 생성됩니다.</p>
         <textarea id="note-modal-text" class="note-modal-textarea" placeholder="메모 내용을 입력하세요..." rows="4"></textarea>
         <div class="note-modal-actions">
           <button type="button" id="note-modal-cancel" class="note-modal-btn note-modal-btn-secondary">취소</button>

--- a/templates/board.html
+++ b/templates/board.html
@@ -502,6 +502,19 @@
       </div>
     </aside>
 
+    <!-- 보드 제목 수정 모달 (보드 생성자만) -->
+    <div class="note-modal" id="board-title-modal" aria-hidden="true">
+      <div class="note-modal-backdrop" data-close="true"></div>
+      <div class="note-modal-panel">
+        <h3 class="note-modal-title">보드 제목 수정</h3>
+        <input type="text" id="board-title-input" class="note-modal-textarea" placeholder="보드 제목" style="margin-bottom:20px;" />
+        <div class="note-modal-actions">
+          <button type="button" id="board-title-cancel" class="note-modal-btn note-modal-btn-secondary">취소</button>
+          <button type="button" id="board-title-save" class="note-modal-btn note-modal-btn-primary">저장</button>
+        </div>
+      </div>
+    </div>
+
     <!-- 새 포스트잇 모달 -->
     <div class="note-modal" id="note-modal" aria-hidden="true">
       <div class="note-modal-backdrop" data-close="true"></div>

--- a/templates/login.html
+++ b/templates/login.html
@@ -49,7 +49,7 @@
         <div id="login-error" class="text-sm text-red-600 hidden"></div>
 
         <div>
-          <button onclick="location.href='register.html'" type="button" id="register-btn"
+          <button type="button" id="register-btn"
             class="flex w-full justify-center rounded-md bg-[#F2F4F8] px-3 py-1.5 text-sm/6 font-semibold text-black shadow-xs focus-visible:outline-2 focus-visible:outline-offset-2">회원가입</button>
         </div>
       </form>


### PR DESCRIPTION

# 요약
- 사용자가 익명일 때 헤더에 로그인 버튼을 두고, 클릭 시 로그인 페이지로 이동
- 보드 타이틀 클릭시 수정 가능(보드 권한자만)
- 이미지 버튼 클릭 후 "위치를 선택해 주세요" 라는 토스트를 띄우기
- + 버튼 클릭시 생성되는 포스트잇의 위치를 화면 중앙에서 마우스 커서 근방으로 조정
- 포스트잇 선택 모달에서 'Delete' 키를 누르면 삭제가 가능하도록 이벤트 처리
- 포스트잇 더블클릭시에도 노란색 테두리가 뜨도록 UI 개선(모달창 해제시 같이 해제)

# 기타 의견
* 공유 성공, 복사 성공 등은 토스트, 삭제 확인 등을 경고창 대신 커스텀 모달로 대체하면 사용자 경험상 더 좋을 것으로 판단
* 409 시 "다른 사용자가 수정했습니다.", "화면을 새로고침했습니다" 등 구체적인 메시지를 모달이나 토스트를 통해 보여주는 것이 사용자 경험상 더 좋을 것으로 판단


