### PR TITLE
Feat/42 image upload

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,6 +24,7 @@ app.config["JWT_SECRET_KEY"] = Config.SECRET_KEY
 app.config["JWT_TOKEN_LOCATION"] = ['cookies']
 app.config["JWT_ACCESS_TOKEN_EXPIRES"] = timedelta(hours=1)
 app.config["JWT_COOKIE_CSRF_PROTECT"] = False  # fetch/AJAX에서 X-CSRF-TOKEN 미전송 시 POST 401 방지
+app.config["IMAGE_BASE_URL"] = Config.IMAGE_BASE_URL
 jwt = JWTManager(app)
 # !!! 로컬 db 설정에 맞춰 수정 필요
 client = MongoClient("mongodb://localhost:27017")

--- a/docs/api-spec-v2.md
+++ b/docs/api-spec-v2.md
@@ -316,6 +316,12 @@
 
 ## 4. 포스트잇 API
 
+**이미지 필드**
+- `image_key`: 업로드 API(5.1) 응답의 `image_key`. 생성/수정 시 이미지 지정용. 응답에는 포함하지 않음.
+- `image_url`: 이미지 표시용 URL. `GET /api/boards/{public_id}/images/{image_ref}` 형식. public_id 변경 시 예전 URL은 404.
+
+---
+
 ### 4.1 포스트잇 생성
 
 **POST** `/api/boards/{public_id}/notes`
@@ -443,7 +449,7 @@
 
 ---
 
-## 5. 이미지 업로드 API
+## 5. 이미지 API
 
 ### 5.1 이미지 업로드 (포스트잇용)
 
@@ -470,11 +476,49 @@
 }
 ```
 
+- `image_key`: 서버 내부 저장 키. 클라이언트는 POST /notes 요청 시 이 값을 사용. 노출하지 않음.
+- `url`: 이미지 조회 URL. `GET /api/boards/{public_id}/images/{image_ref}` 형식. 이 URL을 사용해 이미지를 표시.
+
+**저장 구조**
+- 실제 파일은 `board_id`(MongoDB _id) 기준으로 저장. `public_id`가 변경되어도 기존 이미지 참조 유지.
+- 내부 경로 예: `uploads/boards/{board_id}/{filename}`. `board_id`는 클라이언트에 노출하지 않음.
+
 **에러**
 
 - `400`: 허용 확장자 아님, 3MB 초과, 이미지 아님
 - `401`: 비인증
 - `404`: `BOARD_NOT_FOUND` — 유효하지 않은 보드 링크
+
+---
+
+### 5.2 이미지 조회 (서빙)
+
+**GET** `/api/boards/{public_id}/images/{image_ref}`
+
+| 구분 | 내용 |
+| ---- | ---- |
+| 인증 | 불필요 (보드 접근 가능한 누구나) |
+| 설명 | 포스트잇에 첨부된 이미지 바이너리 반환 |
+
+**파라미터**
+- `public_id`: 보드의 public_id
+- `image_ref`: 이미지 참조 식별자 (업로드 응답의 url에서 추출. 예측 불가능한 값)
+
+**성공 응답** `200 OK`
+- `Content-Type`: `image/jpeg` | `image/png` | `image/gif`
+- Body: 이미지 바이너리
+
+**처리**
+1. `public_id`로 보드 존재 확인
+2. 해당 보드 내 포스트잇 중 `image_ref`에 해당하는 이미지 검색
+3. 파일 반환
+
+**에러**
+- `404`: `BOARD_NOT_FOUND` 또는 `IMAGE_NOT_FOUND` — `public_id`가 변경된 경우 예전 URL은 404 (접근 차단)
+
+**보안**
+- URL에 `public_id` 포함. `public_id` 변경 시 예전 이미지 URL은 모두 404.
+- `board_id`는 URL에 포함하지 않음.
 
 ---
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,3 @@ testpaths = tests
 python_files = test_*.py
 python_functions = test_*
 addopts = -v
-asyncio_default_fixture_loop_scope = function

--- a/routes/boards.py
+++ b/routes/boards.py
@@ -8,12 +8,14 @@
 - 포스트잇 생성 (POST /api/boards/<public_id>/notes)
 - 포스트잇 수정/이동 (PATCH /api/boards/<public_id>/notes/<note_id>)
 - 포스트잇 삭제 (DELETE /api/boards/<public_id>/notes/<note_id>)
+- 이미지 업로드 (POST /api/boards/<public_id>/images)
+- 이미지 조회 (GET /api/boards/<public_id>/images/<image_ref>)
 """
 import os
 import uuid
 
 from bson import ObjectId
-from flask import Blueprint, current_app, jsonify, request
+from flask import Blueprint, current_app, jsonify, request, send_file
 from flask_jwt_extended import get_jwt_identity, jwt_required
 from pymongo import ReturnDocument
 from utils import utc_now
@@ -41,14 +43,14 @@ def _serialize_board(doc, include_created_at=False):
     return out
 
 
-def _serialize_note(doc, image_base_url=None):
+def _serialize_note(doc, public_id=None):
     """sticky_notes 컬렉션 문서를 API 응답 형식으로 변환."""
     if not doc:
         return None
-    image_key = doc.get("image_key")
+    image_key = doc.get("image_key")  # image_ref (filename)
     image_url = None
-    if image_key and image_base_url:
-        image_url = f"{image_base_url.rstrip('/')}/{image_key}"
+    if image_key and public_id:
+        image_url = f"/api/boards/{public_id}/images/{image_key}"
     return {
         "id": str(doc["_id"]),
         "owner_user_id": str(doc["owner_user_id"]),
@@ -179,11 +181,9 @@ def get_board(public_id: str):
         current_app.logger.exception("get_board notes: %s", e)
         return jsonify({"error": {"code": "INTERNAL_ERROR", "message": "보드를 불러올 수 없습니다.", "details": {}}}), 500
 
-    image_base_url = current_app.config.get("IMAGE_BASE_URL") or ""
-
     payload = {
         "board": _serialize_board(board),
-        "notes": [_serialize_note(n, image_base_url) for n in notes_list],
+        "notes": [_serialize_note(n, public_id=public_id) for n in notes_list],
     }
     if current_user_id:
         payload["current_user_id"] = str(current_user_id)
@@ -383,8 +383,7 @@ def create_note(public_id: str):
     ins = sticky_notes.insert_one(note_doc)
     note_doc["_id"] = ins.inserted_id
 
-    image_base_url = current_app.config.get("IMAGE_BASE_URL") or ""
-    return jsonify(_serialize_note(note_doc, image_base_url)), 201
+    return jsonify(_serialize_note(note_doc, public_id=public_id)), 201
 
 
 # ---------------------------------------------------------------------------
@@ -440,18 +439,70 @@ def upload_image(public_id: str):
             "error": {"code": "VALIDATION_ERROR", "message": "이미지는 3MB 이하여야 합니다.", "details": {}}
         }), 400
 
+    board_id = board["_id"]
     base_dir = current_app.static_folder or "static"
-    upload_dir = os.path.join(base_dir, "uploads", "boards", public_id)
+    upload_dir = os.path.join(base_dir, "uploads", "boards", str(board_id))
     os.makedirs(upload_dir, exist_ok=True)
-    filename = f"{uuid.uuid4().hex}{ext}"
-    filepath = os.path.join(upload_dir, filename)
+    image_ref = f"{uuid.uuid4().hex}{ext}"
+    filepath = os.path.join(upload_dir, image_ref)
     file.save(filepath)
 
-    image_key = f"uploads/boards/{public_id}/{filename}"
-    base_url = request.url_root.rstrip("/")
-    image_url = f"{base_url}/static/{image_key}"
+    # image_key: 클라이언트가 POST /notes 시 사용. 노트에 저장.
+    # url: GET /api/boards/{public_id}/images/{image_ref} 형식
+    image_url = f"/api/boards/{public_id}/images/{image_ref}"
+    return jsonify({"image_key": image_ref, "url": image_url}), 201
 
-    return jsonify({"image_key": image_key, "url": image_url}), 201
+
+# ---------------------------------------------------------------------------
+# GET /api/boards/<public_id>/images/<image_ref> - 이미지 조회 (서빙)
+# ---------------------------------------------------------------------------
+IMAGE_EXT_TO_MIME = {
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".gif": "image/gif",
+}
+
+
+@boards_bp.route("/<public_id>/images/<path:image_ref>", methods=["GET"])
+def get_image(public_id: str, image_ref: str):
+    """포스트잇에 첨부된 이미지 바이너리 반환. 인증 불필요."""
+    db = getattr(current_app, "db", None)
+    if db is None:
+        return jsonify({"error": {"code": "INTERNAL_ERROR", "message": "DB not configured."}}), 500
+
+    boards = db["boards"]
+    sticky_notes = db["sticky_notes"]
+
+    board = boards.find_one({"public_id": public_id})
+    if not board:
+        return jsonify({
+            "error": {"code": "BOARD_NOT_FOUND", "message": "유효하지 않은 보드 링크입니다.", "details": {}}
+        }), 404
+
+    # 해당 보드 내 포스트잇 중 image_ref에 해당하는 이미지 검색
+    note = sticky_notes.find_one({"board_id": board["_id"], "image_key": image_ref})
+    if not note:
+        return jsonify({
+            "error": {"code": "IMAGE_NOT_FOUND", "message": "이미지를 찾을 수 없습니다.", "details": {}}
+        }), 404
+
+    base_dir = current_app.static_folder or "static"
+    # 신규: image_key=filename, 저장 경로 uploads/boards/{board_id}/{filename}
+    # 구버전: image_key=uploads/boards/{public_id}/{filename}
+    if "/" in image_ref:
+        filepath = os.path.join(base_dir, image_ref)
+    else:
+        filepath = os.path.join(base_dir, "uploads", "boards", str(board["_id"]), image_ref)
+    if not os.path.isfile(filepath):
+        return jsonify({
+            "error": {"code": "IMAGE_NOT_FOUND", "message": "이미지를 찾을 수 없습니다.", "details": {}}
+        }), 404
+
+    ext = os.path.splitext(image_ref)[1].lower()
+    mimetype = IMAGE_EXT_TO_MIME.get(ext, "application/octet-stream")
+
+    return send_file(filepath, mimetype=mimetype)
 
 
 # ---------------------------------------------------------------------------
@@ -558,8 +609,7 @@ def update_note(public_id: str, note_id: str):
         }), 409
 
     updated = sticky_notes.find_one({"_id": oid})
-    image_base_url = current_app.config.get("IMAGE_BASE_URL") or ""
-    return jsonify(_serialize_note(updated, image_base_url)), 200
+    return jsonify(_serialize_note(updated, public_id=public_id)), 200
 
 
 # ---------------------------------------------------------------------------

--- a/static/js/board.js
+++ b/static/js/board.js
@@ -85,8 +85,10 @@ $(document).ready(function () {
     const isBoardOwner = !!(currentUserId && board && String(board.owner_user_id) === String(currentUserId));
     if (isBoardOwner) {
       $('#board-title').css('cursor', 'pointer');
+      $('#wingbar-regenerate-link').show();
     } else {
       $('#board-title').css('cursor', 'default');
+      $('#wingbar-regenerate-link').hide();
     }
   }
 
@@ -264,6 +266,56 @@ $(document).ready(function () {
     const noteId = $(this).attr('data-note-id');
     highlightNote(noteId);
     openNoteDetailModal(noteId);
+  });
+
+  // 링크 재발급 (보드 생성자만)
+  function openLinkRegenerateModal() {
+    $('#link-regenerate-modal').addClass('is-open').attr('aria-hidden', 'false');
+  }
+  function closeLinkRegenerateModal() {
+    $('#link-regenerate-modal').removeClass('is-open').attr('aria-hidden', 'true');
+  }
+  $('#wingbar-regenerate-link').on('click', function () {
+    closeWingbar();
+    openLinkRegenerateModal();
+  });
+  $(document).on('click', '#link-regenerate-modal .note-modal-backdrop[data-close="true"]', closeLinkRegenerateModal);
+  $('#link-regenerate-cancel').on('click', closeLinkRegenerateModal);
+  $('#link-regenerate-confirm').on('click', function () {
+    const newPublicId = typeof crypto !== 'undefined' && crypto.randomUUID
+      ? crypto.randomUUID()
+      : 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+          const r = (Math.random() * 16) | 0;
+          const v = c === 'x' ? r : (r & 0x3) | 0x8;
+          return v.toString(16);
+        });
+    const $btn = $('#link-regenerate-confirm');
+    $btn.prop('disabled', true);
+    fetch(`/api/boards/${publicId}`, {
+      method: 'PATCH',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ public_id: newPublicId }),
+    })
+      .then(async (res) => {
+        if (res.status === 401) { showLoginRequiredModal(); return null; }
+        if (res.status === 403) { alert('보드 생성자만 링크를 변경할 수 있습니다.'); return null; }
+        if (!res.ok) {
+          const d = await res.json().catch(() => ({}));
+          throw new Error(d?.error?.message || '링크 변경에 실패했습니다.');
+        }
+        return res.json();
+      })
+      .then((data) => {
+        if (data && data.public_id) {
+          closeLinkRegenerateModal();
+          window.location.href = '/boards/' + data.public_id;
+        }
+      })
+      .catch((err) => {
+        $btn.prop('disabled', false);
+        alert(err.message);
+      });
   });
 
   let pendingNotePosition = null; // 더블클릭 시 생성 위치 저장 (null이면 + 버튼 경로)

--- a/static/js/board.js
+++ b/static/js/board.js
@@ -238,11 +238,28 @@ $(document).ready(function () {
   });
 
   // 이미지 추가 모드
+  function openImageGuideModal() {
+    $('#image-guide-modal').addClass('is-open').attr('aria-hidden', 'false');
+  }
+  function closeImageGuideModal() {
+    $('#image-guide-modal').removeClass('is-open').attr('aria-hidden', 'true');
+  }
   $('#btn-add-image').on('click', function (e) {
     e.stopPropagation();
-    imageInsertMode = !imageInsertMode;
-    $(this).toggleClass('image-mode-active', imageInsertMode);
-    if (!imageInsertMode) closeImageModal();
+    if (imageInsertMode) {
+      imageInsertMode = false;
+      $(this).removeClass('image-mode-active');
+      closeImageModal();
+    } else {
+      openImageGuideModal();
+    }
+  });
+  $(document).on('click', '#image-guide-modal .note-modal-backdrop[data-close="true"]', closeImageGuideModal);
+  $('#image-guide-cancel').on('click', closeImageGuideModal);
+  $('#image-guide-confirm').on('click', function () {
+    closeImageGuideModal();
+    imageInsertMode = true;
+    $('#btn-add-image').addClass('image-mode-active');
   });
 
   // 윙바

--- a/templates/board.html
+++ b/templates/board.html
@@ -160,7 +160,14 @@
       }
       .wingbar-item:hover {
         background: #f3f4f6;
-        color: #111827;
+      }
+      .wingbar-item-btn {
+        width: 100%;
+        text-align: left;
+        border: none;
+        background: transparent;
+        cursor: pointer;
+        font: inherit;
       }
       .wingbar-item-icon {
         font-size: 18px;
@@ -494,6 +501,10 @@
           <span class="wingbar-item-icon">≡</span>
           <span>내 보드 목록</span>
         </a>
+        <button type="button" id="wingbar-regenerate-link" class="wingbar-item wingbar-item-btn" style="display:none;">
+          <span class="wingbar-item-icon">🔗</span>
+          <span>링크 재발급</span>
+        </button>
         <div class="wingbar-section">
           <h3 class="wingbar-section-title">내가 쓴 메모</h3>
           <ul class="wingbar-note-list" id="wingbar-my-notes"></ul>
@@ -501,6 +512,19 @@
         </div>
       </div>
     </aside>
+
+    <!-- 링크 재발급 확인 모달 (보드 생성자만) -->
+    <div class="note-modal" id="link-regenerate-modal" aria-hidden="true">
+      <div class="note-modal-backdrop" data-close="true"></div>
+      <div class="note-modal-panel">
+        <h3 class="note-modal-title">링크 재발급</h3>
+        <p class="note-modal-hint">기존 공유 링크가 즉시 무효화됩니다. 새 링크로 변경하시겠습니까?</p>
+        <div class="note-modal-actions">
+          <button type="button" id="link-regenerate-cancel" class="note-modal-btn note-modal-btn-secondary">취소</button>
+          <button type="button" id="link-regenerate-confirm" class="note-modal-btn note-modal-btn-primary">변경</button>
+        </div>
+      </div>
+    </div>
 
     <!-- 보드 제목 수정 모달 (보드 생성자만) -->
     <div class="note-modal" id="board-title-modal" aria-hidden="true">

--- a/templates/board.html
+++ b/templates/board.html
@@ -589,6 +589,19 @@
       </div>
     </div>
 
+    <!-- 이미지 추가 안내 모달 -->
+    <div class="note-modal" id="image-guide-modal" aria-hidden="true">
+      <div class="note-modal-backdrop" data-close="true"></div>
+      <div class="note-modal-panel">
+        <h3 class="note-modal-title">이미지 추가</h3>
+        <p class="note-modal-hint">확인을 누른 뒤, 보드에서 이미지를 넣을 위치를 클릭하세요. jpg, png, gif (최대 3MB)를 지원합니다.</p>
+        <div class="note-modal-actions">
+          <button type="button" id="image-guide-cancel" class="note-modal-btn note-modal-btn-secondary">취소</button>
+          <button type="button" id="image-guide-confirm" class="note-modal-btn note-modal-btn-primary">확인</button>
+        </div>
+      </div>
+    </div>
+
     <!-- 이미지 삽입 모달 -->
     <div class="image-modal" id="image-modal" aria-hidden="true">
       <div class="image-modal-backdrop" data-close="true"></div>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,3 +70,11 @@ def auth_client(client):
             return client.delete(url, **kwargs)
 
     return AuthClient()
+
+
+@pytest.fixture
+def board_with_public_id(auth_client):
+    """보드 생성 후 public_id 반환."""
+    res = auth_client.post("/api/boards", json={"title": "이미지테스트보드"})
+    assert res.status_code == 201
+    return res.get_json()["public_id"]

--- a/tests/test_boards.py
+++ b/tests/test_boards.py
@@ -1,7 +1,16 @@
 """
 보드 API 테스트.
 """
+import io
+
 import pytest
+
+# 1x1 픽셀 PNG (유효한 이미지 파일)
+MINIMAL_PNG_BYTES = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc\x00\x01"
+    b"\x00\x00\x05\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82"
+)
 
 
 class TestCreateBoard:
@@ -105,3 +114,127 @@ class TestCreateNote:
         assert data["y"] == 200
         assert "id" in data
         assert data["version"] == 0
+
+
+class TestUploadImage:
+    """POST /api/boards/<public_id>/images - 이미지 업로드"""
+
+    def test_비인증_401(self, client, board_with_public_id):
+        """인증 없이 업로드 시 401"""
+        public_id = board_with_public_id
+        data = {"file": (io.BytesIO(MINIMAL_PNG_BYTES), "test.png")}
+        res = client.post(f"/api/boards/{public_id}/images", data=data)
+        assert res.status_code == 401
+        assert res.get_json()["error"]["code"] == "UNAUTHORIZED"
+
+    def test_존재하지_않는_보드_404(self, auth_client):
+        """유효하지 않은 public_id 시 404"""
+        data = {"file": (io.BytesIO(MINIMAL_PNG_BYTES), "test.png")}
+        res = auth_client.post(
+            "/api/boards/00000000-0000-0000-0000-000000000000/images",
+            data=data,
+        )
+        assert res.status_code == 404
+        assert res.get_json()["error"]["code"] == "BOARD_NOT_FOUND"
+
+    def test_파일_없음_400(self, auth_client, board_with_public_id):
+        """file 필드 없을 때 400"""
+        res = auth_client.post(
+            f"/api/boards/{board_with_public_id}/images",
+            data={},
+        )
+        assert res.status_code == 400
+
+    def test_빈_파일_400(self, auth_client, board_with_public_id):
+        """파일명 없거나 빈 파일 시 400"""
+        data = {"file": (io.BytesIO(b""), "")}
+        res = auth_client.post(
+            f"/api/boards/{board_with_public_id}/images",
+            data=data,
+        )
+        assert res.status_code == 400
+
+    def test_허용_확장자_아님_400(self, auth_client, board_with_public_id):
+        """jpg, jpeg, png, gif 외 확장자 시 400"""
+        data = {"file": (io.BytesIO(b"not an image"), "test.txt")}
+        res = auth_client.post(
+            f"/api/boards/{board_with_public_id}/images",
+            data=data,
+        )
+        assert res.status_code == 400
+        assert "VALIDATION_ERROR" in str(res.get_json())
+
+    def test_업로드_성공_201(self, auth_client, board_with_public_id):
+        """유효한 PNG 업로드 시 201, image_key와 url 반환"""
+        public_id = board_with_public_id
+        data = {"file": (io.BytesIO(MINIMAL_PNG_BYTES), "test.png")}
+        res = auth_client.post(f"/api/boards/{public_id}/images", data=data)
+        assert res.status_code == 201
+        body = res.get_json()
+        assert "image_key" in body
+        assert "url" in body
+        assert body["url"] == f"/api/boards/{public_id}/images/{body['image_key']}"
+        assert body["image_key"].endswith(".png")
+
+
+class TestGetImage:
+    """GET /api/boards/<public_id>/images/<image_ref> - 이미지 조회"""
+
+    def test_존재하지_않는_보드_404(self, client):
+        """유효하지 않은 public_id 시 404"""
+        res = client.get(
+            "/api/boards/00000000-0000-0000-0000-000000000000/images/abc123.png"
+        )
+        assert res.status_code == 404
+        assert res.get_json()["error"]["code"] == "BOARD_NOT_FOUND"
+
+    def test_노트에_없는_이미지_404(self, auth_client, board_with_public_id):
+        """업로드만 하고 노트에 첨부 안 한 이미지 요청 시 404"""
+        public_id = board_with_public_id
+        # 업로드
+        data = {"file": (io.BytesIO(MINIMAL_PNG_BYTES), "test.png")}
+        up = auth_client.post(f"/api/boards/{public_id}/images", data=data)
+        assert up.status_code == 201
+        image_key = up.get_json()["image_key"]
+        # 노트 생성 없이 바로 이미지 조회 → 노트에 없으므로 404
+        res = auth_client.get(f"/api/boards/{public_id}/images/{image_key}")
+        # 또는 client (비인증)로 조회해도 404 (노트에 연결 안 됨)
+        assert res.status_code == 404
+        assert res.get_json()["error"]["code"] == "IMAGE_NOT_FOUND"
+
+    def test_이미지_조회_성공_200(self, auth_client, board_with_public_id):
+        """업로드 후 노트에 첨부하면 이미지 조회 가능 (인증 불필요)"""
+        public_id = board_with_public_id
+        # 1. 업로드
+        data = {"file": (io.BytesIO(MINIMAL_PNG_BYTES), "test.png")}
+        up = auth_client.post(f"/api/boards/{public_id}/images", data=data)
+        assert up.status_code == 201
+        image_key = up.get_json()["image_key"]
+        # 2. 노트 생성 (image_key 포함)
+        note = auth_client.post(
+            f"/api/boards/{public_id}/notes",
+            json={"text": "", "x": 0, "y": 0, "image_key": image_key},
+        )
+        assert note.status_code == 201
+        assert note.get_json().get("image_url") == f"/api/boards/{public_id}/images/{image_key}"
+        # 3. 이미지 조회 (비인증 client로 가능)
+        res = auth_client.get(f"/api/boards/{public_id}/images/{image_key}")
+        assert res.status_code == 200
+        assert res.content_type.startswith("image/")
+        assert res.data == MINIMAL_PNG_BYTES
+
+    def test_비인증으로_이미지_조회_가능(self, auth_client, client, board_with_public_id):
+        """이미지 조회는 인증 없이 가능"""
+        public_id = board_with_public_id
+        data = {"file": (io.BytesIO(MINIMAL_PNG_BYTES), "test.png")}
+        up = auth_client.post(f"/api/boards/{public_id}/images", data=data)
+        assert up.status_code == 201
+        image_key = up.get_json()["image_key"]
+        auth_client.post(
+            f"/api/boards/{public_id}/notes",
+            json={"text": "", "x": 0, "y": 0, "image_key": image_key},
+        )
+        # 비인증 client로 조회
+        res = client.get(f"/api/boards/{public_id}/images/{image_key}")
+        assert res.status_code == 200
+        assert res.data == MINIMAL_PNG_BYTES


### PR DESCRIPTION
# 요약
- 보드 포스트잇 이미지 업로드 기능 및 관련 UI/API 구현
- api 문서 수정(이미지 관련 부분)
- 보드 주인을 위한 링크 재발급 기능 추가

# 주요 변경사항
## API
- 이미지 업로드: 이미지 고아 방지를 위해 public_id 대신 board_id 기반 저장으로 변경
  (GET /api/boards/{public_id}/images/{image_ref} 조회 엔드포인트 추가)
- public_id 변경 시 기존 이미지 URL 404 처리 (보안)

## 설정
- IMAGE_BASE_URL 환경 변수 연동 (app.py)

## UI
- 보드 주인용 링크 재발급(public_id 변경) 기능 (윙바 메뉴에 추가)
- 이미지 아이콘 클릭 시 안내 모달 추가 ("확인 후 보드에서 위치 클릭" 안내)

## 테스트
- 이미지 업로드/조회 API 테스트 추가
- pytest asyncio 설정 경고 제거