### PR TITLE
Feat/45 board delete snapshot

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ from flask_jwt_extended import (
 from datetime import timedelta
 from pymongo import MongoClient
 from routes.boards import boards_bp
+from routes.snapshots import snapshots_bp
 from extensions import socketio
 import sockets
 
@@ -35,6 +36,7 @@ socketio.init_app(app)
 
 # Blueprint 등록
 app.register_blueprint(boards_bp)
+app.register_blueprint(snapshots_bp)
 
 
 

--- a/docs/api-spec-v2.md
+++ b/docs/api-spec-v2.md
@@ -290,12 +290,28 @@
 | 인증 | 필수 (보드 생성자만)                                           |
 | 설명 | 보드 삭제. 최종 스냅샷을 이미지로 저장 후 보드 소유자에게 귀속 |
 
+**클라이언트 흐름**
+
+1. 삭제 확인 시점에 html2canvas 등으로 보드 영역 캡처
+2. `POST /api/snapshots`로 캡처 이미지 업로드 → `image_key` 수신
+3. 본 API 호출 시 Request Body에 `image_key` 포함
+
+**Request Body (선택)**
+
+```json
+{
+  "image_key": "string"
+}
+```
+
+- `image_key`: `POST /api/snapshots` 응답에서 받은 값. 생략 시 스냅샷 이미지 없이 레코드만 저장(`image_key=""`).
+
 **삭제 방식**: 보드·포스트잇은 **물리 삭제(hard delete)**. soft delete 미사용.
 
-**처리 순서**
+**서버 처리 순서**
 
-1. 스냅샷 이미지 파일 생성 (외부 스토리지/로컬 디스크)
-2. snapshots 컬렉션에 레코드 저장 (소유자 귀속)
+1. Request Body의 `image_key` 사용 (없으면 빈 문자열)
+2. snapshots 컬렉션에 레코드 저장 (소유자 귀속, `is_public: false`)
 3. `sticky_notes.deleteMany({ board_id })` → `boards.deleteOne({ _id })`. notes를 먼저 삭제한 뒤 boards 문서 삭제. (boards 삭제 시 note_count는 문서와 함께 사라지므로 별도 정리 불필요)
 4. 해당 보드 room에 `board_invalidated` broadcast (7.2 참고)
 
@@ -524,7 +540,45 @@
 
 ## 6. 스냅샷 API
 
-### 6.1 내 스냅샷 목록
+### 6.1 스냅샷 이미지 업로드 (보드 삭제 직전용)
+
+**POST** `/api/snapshots`
+
+| 구분 | 내용 |
+| ---- | ---- |
+| 인증 | 필수 (보드 생성자만) |
+| 설명 | 보드 삭제 직전 클라이언트(html2canvas 등)가 캡처한 이미지 업로드. 반환된 `image_key`를 `DELETE /api/boards/{public_id}` 요청 본문에 포함 |
+
+**Content-Type** `multipart/form-data`
+
+**Request Body (Form)**
+
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|------|------|
+| file | File | O | 캡처한 이미지 파일 (jpg, jpeg, png, gif, 최대 5MB) |
+| board_public_id | string | O | 대상 보드의 public_id |
+
+**성공 응답** `201 Created`
+
+```json
+{
+  "image_key": "string"
+}
+```
+
+- `image_key`: 저장된 이미지 경로. `uploads/snapshots/{owner_id}/{filename}` 형식. `DELETE /api/boards/{public_id}` 본문에 그대로 전달.
+
+**에러**
+
+- `400`: `board_public_id` 누락
+- `401`: 비인증
+- `403`: 보드 생성자 아님
+- `404`: `BOARD_NOT_FOUND`
+- `400`: file 누락, 허용 확장자 아님, 5MB 초과
+
+---
+
+### 6.2 내 스냅샷 목록
 
 **GET** `/api/snapshots/mine`
 
@@ -532,6 +586,8 @@
 | ---- | ------------------------------ |
 | 인증 | 필수                           |
 | 설명 | 나에게 귀속된 보드 스냅샷 목록 |
+
+※ `image_url`은 `GET /api/snapshots/{id}/image` 형식.
 
 **Query Parameters**
 
@@ -556,7 +612,33 @@
 
 ---
 
-### 6.2 스냅샷 공개 여부 토글
+### 6.3 스냅샷 이미지 조회
+
+**GET** `/api/snapshots/{snapshot_id}/image`
+
+| 구분 | 내용 |
+| ---- | ---- |
+| 인증 | 불필요 (단, 비공개 스냅샷은 소유자만) |
+| 설명 | 스냅샷 이미지 바이너리 반환 |
+
+**성공 응답** `200 OK`
+
+- `Content-Type`: `image/jpeg` | `image/png` | `image/gif`
+- Body: 이미지 바이너리
+
+**접근 제어**
+- 스냅샷이 `is_public: true` → 누구나 조회 가능
+- 스냅샷이 `is_public: false` → 소유자만 조회 가능
+
+**에러**
+
+- `404`: `SNAPSHOT_NOT_FOUND` — 스냅샷 없음
+- `403`: 비공개 스냅샷에 대한 비소유자 접근
+- `404`: `IMAGE_NOT_FOUND` — image_key 없음 또는 파일 미존재
+
+---
+
+### 6.4 스냅샷 공개 여부 토글
 
 **PATCH** `/api/snapshots/{snapshot_id}`
 
@@ -590,7 +672,7 @@
 
 ---
 
-### 6.3 공개 스냅샷 게시판
+### 6.5 공개 스냅샷 게시판
 
 **GET** `/api/snapshots/public`
 

--- a/extensions.py
+++ b/extensions.py
@@ -1,3 +1,4 @@
 from flask_socketio import SocketIO
 
-socketio = SocketIO(cors_allowed_origins=['http://localhost:5001'], manage_session=False)
+#! 로컬 개발용으로 모든 출처허용 배포시 수정 필요!
+socketio = SocketIO(cors_allowed_origins='*', manage_session=False)

--- a/routes/boards.py
+++ b/routes/boards.py
@@ -286,11 +286,15 @@ def delete_board(public_id: str):
     board_id = board["_id"]
     owner_id = board["owner_user_id"]
 
-    # 1. 스냅샷 레코드 저장 (이미지 생성은 TODO, 레코드만 먼저 저장)
+    # image_key: 클라이언트가 POST /api/snapshots로 업로드 후 본문에 포함
+    data = request.get_json(silent=True) or {}
+    image_key = data.get("image_key") or ""
+
+    # 1. 스냅샷 레코드 저장
     try:
         snapshots.insert_one({
             "board_owner_id": owner_id,
-            "image_key": "",  # TODO: 실제 스냅샷 이미지 저장
+            "image_key": image_key,
             "is_public": False,
             "created_at": now,
         })

--- a/routes/snapshots.py
+++ b/routes/snapshots.py
@@ -98,6 +98,7 @@ def upload_snapshot():
     image_key = f"uploads/snapshots/{owner_id}/{filename}"
     return jsonify({"image_key": image_key}), 201
 
+# *** Todo: 이하 내용은 스냅샷 게시판에 필요한 api 초안입니다. 필요시 수정해서 사용하세요. ***
 
 # ---------------------------------------------------------------------------
 # GET /api/snapshots/mine - 내 스냅샷 목록
@@ -175,6 +176,7 @@ def list_public():
 # GET /api/snapshots/<id>/image - 스냅샷 이미지 조회
 # ---------------------------------------------------------------------------
 @snapshots_bp.route("/<snapshot_id>/image", methods=["GET"])
+@jwt_required(optional=True)
 def get_snapshot_image(snapshot_id: str):
     """스냅샷 이미지 반환. 소유자 또는 공개된 경우만 허용."""
     db = getattr(current_app, "db", None)

--- a/routes/snapshots.py
+++ b/routes/snapshots.py
@@ -1,0 +1,264 @@
+"""
+스냅샷 API
+- POST /api/snapshots - 보드 삭제 직전 클라이언트 캡처 이미지 업로드 (image_key 반환)
+- GET /api/snapshots/mine - 내 스냅샷 목록
+- GET /api/snapshots/public - 공개 스냅샷 목록
+- GET /api/snapshots/<id>/image - 스냅샷 이미지 조회
+- PATCH /api/snapshots/<id> - 공개/비공개 토글
+"""
+import os
+import uuid
+
+from bson import ObjectId
+from flask import Blueprint, current_app, jsonify, request, send_file
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from utils import utc_now
+
+snapshots_bp = Blueprint("snapshots", __name__, url_prefix="/api/snapshots")
+
+ALLOWED_EXT = {".jpg", ".jpeg", ".png", ".gif"}
+MAX_SIZE = 5 * 1024 * 1024  # 5MB (스냅샷은 보드 전체이므로 포스트잇 이미지보다 큼)
+EXT_TO_MIME = {".jpg": "image/jpeg", ".jpeg": "image/jpeg", ".png": "image/png", ".gif": "image/gif"}
+
+
+def _get_current_user_id():
+    return get_jwt_identity()
+
+
+# ---------------------------------------------------------------------------
+# POST /api/snapshots - 스냅샷 이미지 업로드 (삭제 직전 클라이언트 캡처용)
+# ---------------------------------------------------------------------------
+@snapshots_bp.route("", methods=["POST"])
+@jwt_required(optional=True)
+def upload_snapshot():
+    """
+    보드 삭제 직전 클라이언트(html2canvas 등)가 캡처한 이미지 업로드.
+    반환된 image_key를 DELETE /api/boards/{public_id} 요청 본문에 포함하여 전달.
+    """
+    user_id = _get_current_user_id()
+    if not user_id:
+        return jsonify({"error": {"code": "UNAUTHORIZED", "message": "로그인이 필요합니다.", "details": {}}}), 401
+
+    db = getattr(current_app, "db", None)
+    if db is None:
+        return jsonify({"error": {"code": "INTERNAL_ERROR", "message": "DB not configured."}}), 500
+
+    board_public_id = request.form.get("board_public_id")
+    if not board_public_id:
+        return jsonify({
+            "error": {"code": "VALIDATION_ERROR", "message": "board_public_id가 필요합니다.", "details": {}}
+        }), 400
+
+    board = db["boards"].find_one({"public_id": board_public_id})
+    if not board:
+        return jsonify({
+            "error": {"code": "BOARD_NOT_FOUND", "message": "유효하지 않은 보드 링크입니다.", "details": {}}
+        }), 404
+
+    if str(board["owner_user_id"]) != str(user_id):
+        return jsonify({
+            "error": {"code": "FORBIDDEN", "message": "보드 생성자만 스냅샷을 생성할 수 있습니다.", "details": {}}
+        }), 403
+
+    if "file" not in request.files:
+        return jsonify({
+            "error": {"code": "VALIDATION_ERROR", "message": "이미지 파일이 필요합니다.", "details": {}}
+        }), 400
+
+    file = request.files["file"]
+    if not file or not file.filename:
+        return jsonify({
+            "error": {"code": "VALIDATION_ERROR", "message": "파일을 선택해 주세요.", "details": {}}
+        }), 400
+
+    ext = os.path.splitext(file.filename)[1].lower()
+    if ext not in ALLOWED_EXT:
+        return jsonify({
+            "error": {"code": "VALIDATION_ERROR", "message": "jpg, jpeg, png, gif만 업로드 가능합니다.", "details": {}}
+        }), 400
+
+    file.seek(0, os.SEEK_END)
+    size = file.tell()
+    file.seek(0)
+    if size > MAX_SIZE:
+        return jsonify({
+            "error": {"code": "VALIDATION_ERROR", "message": "스냅샷 이미지는 5MB 이하여야 합니다.", "details": {}}
+        }), 400
+
+    owner_id = str(board["owner_user_id"])
+    base_dir = current_app.static_folder or "static"
+    upload_dir = os.path.join(base_dir, "uploads", "snapshots", owner_id)
+    os.makedirs(upload_dir, exist_ok=True)
+    filename = f"{uuid.uuid4().hex}{ext}"
+    filepath = os.path.join(upload_dir, filename)
+    file.save(filepath)
+
+    # image_key: uploads/snapshots/{owner_id}/{filename}
+    image_key = f"uploads/snapshots/{owner_id}/{filename}"
+    return jsonify({"image_key": image_key}), 201
+
+
+# ---------------------------------------------------------------------------
+# GET /api/snapshots/mine - 내 스냅샷 목록
+# ---------------------------------------------------------------------------
+@snapshots_bp.route("/mine", methods=["GET"])
+@jwt_required()
+def list_mine():
+    """나에게 귀속된 보드 스냅샷 목록."""
+    user_id = _get_current_user_id()
+    if not user_id:
+        return jsonify({"error": {"code": "UNAUTHORIZED", "message": "로그인이 필요합니다.", "details": {}}}), 401
+
+    db = getattr(current_app, "db", None)
+    if db is None:
+        return jsonify({"error": {"code": "INTERNAL_ERROR", "message": "DB not configured."}}), 500
+
+    page = max(1, int(request.args.get("page", 1)))
+    limit = min(100, max(1, int(request.args.get("limit", 20))))
+    skip = (page - 1) * limit
+
+    snapshots = db["snapshots"]
+    total = snapshots.count_documents({"board_owner_id": user_id})
+    cursor = snapshots.find({"board_owner_id": user_id}).sort("created_at", -1).skip(skip).limit(limit)
+    items = list(cursor)
+
+    def _serialize(doc):
+        return {
+            "id": str(doc["_id"]),
+            "image_url": f"/api/snapshots/{doc['_id']}/image",
+            "is_public": doc.get("is_public", False),
+            "created_at": doc["created_at"].isoformat() if doc.get("created_at") else None,
+        }
+
+    return jsonify({"snapshots": [_serialize(d) for d in items], "total": total}), 200
+
+
+# ---------------------------------------------------------------------------
+# GET /api/snapshots/public - 공개 스냅샷 목록
+# ---------------------------------------------------------------------------
+@snapshots_bp.route("/public", methods=["GET"])
+def list_public():
+    """모든 사용자가 공개한 스냅샷 목록."""
+    db = getattr(current_app, "db", None)
+    if db is None:
+        return jsonify({"error": {"code": "INTERNAL_ERROR", "message": "DB not configured."}}), 500
+
+    page = max(1, int(request.args.get("page", 1)))
+    limit = min(100, max(1, int(request.args.get("limit", 20))))
+    skip = (page - 1) * limit
+
+    snapshots = db["snapshots"]
+    users = db["users"]
+    total = snapshots.count_documents({"is_public": True})
+    cursor = snapshots.find({"is_public": True}).sort("created_at", -1).skip(skip).limit(limit)
+    items = list(cursor)
+
+    owner_ids = list({str(d["board_owner_id"]) for d in items})
+    user_map = {}
+    if owner_ids:
+        for u in users.find({"user_id": {"$in": owner_ids}}):
+            user_map[str(u["user_id"])] = u.get("username", "")
+
+    def _serialize(doc):
+        return {
+            "id": str(doc["_id"]),
+            "image_url": f"/api/snapshots/{doc['_id']}/image",
+            "owner_username": user_map.get(str(doc["board_owner_id"]), ""),
+            "created_at": doc["created_at"].isoformat() if doc.get("created_at") else None,
+        }
+
+    return jsonify({"snapshots": [_serialize(d) for d in items], "total": total}), 200
+
+
+# ---------------------------------------------------------------------------
+# GET /api/snapshots/<id>/image - 스냅샷 이미지 조회
+# ---------------------------------------------------------------------------
+@snapshots_bp.route("/<snapshot_id>/image", methods=["GET"])
+def get_snapshot_image(snapshot_id: str):
+    """스냅샷 이미지 반환. 소유자 또는 공개된 경우만 허용."""
+    db = getattr(current_app, "db", None)
+    if db is None:
+        return jsonify({"error": {"code": "INTERNAL_ERROR", "message": "DB not configured."}}), 500
+
+    try:
+        oid = ObjectId(snapshot_id)
+    except Exception:
+        return jsonify({
+            "error": {"code": "SNAPSHOT_NOT_FOUND", "message": "스냅샷을 찾을 수 없습니다.", "details": {}}
+        }), 404
+
+    snap = db["snapshots"].find_one({"_id": oid})
+    if not snap:
+        return jsonify({
+            "error": {"code": "SNAPSHOT_NOT_FOUND", "message": "스냅샷을 찾을 수 없습니다.", "details": {}}
+        }), 404
+
+    user_id = _get_current_user_id()
+    owner_id = str(snap["board_owner_id"])
+    is_public = snap.get("is_public", False)
+
+    if not is_public and str(user_id) != owner_id:
+        return jsonify({
+            "error": {"code": "FORBIDDEN", "message": "접근 권한이 없습니다.", "details": {}}
+        }), 403
+
+    image_key = snap.get("image_key")
+    if not image_key:
+        return jsonify({
+            "error": {"code": "IMAGE_NOT_FOUND", "message": "이미지가 없습니다.", "details": {}}
+        }), 404
+
+    base_dir = current_app.static_folder or "static"
+    filepath = os.path.join(base_dir, image_key)
+    if not os.path.isfile(filepath):
+        return jsonify({
+            "error": {"code": "IMAGE_NOT_FOUND", "message": "이미지 파일을 찾을 수 없습니다.", "details": {}}
+        }), 404
+
+    ext = os.path.splitext(image_key)[1].lower()
+    mimetype = EXT_TO_MIME.get(ext, "application/octet-stream")
+    return send_file(filepath, mimetype=mimetype)
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/snapshots/<id> - 공개/비공개 토글
+# ---------------------------------------------------------------------------
+@snapshots_bp.route("/<snapshot_id>", methods=["PATCH"])
+@jwt_required()
+def update_snapshot(snapshot_id: str):
+    """스냅샷 공개 여부 토글. 소유자만 가능."""
+    user_id = _get_current_user_id()
+    if not user_id:
+        return jsonify({"error": {"code": "UNAUTHORIZED", "message": "로그인이 필요합니다.", "details": {}}}), 401
+
+    db = getattr(current_app, "db", None)
+    if db is None:
+        return jsonify({"error": {"code": "INTERNAL_ERROR", "message": "DB not configured."}}), 500
+
+    try:
+        oid = ObjectId(snapshot_id)
+    except Exception:
+        return jsonify({
+            "error": {"code": "SNAPSHOT_NOT_FOUND", "message": "스냅샷을 찾을 수 없습니다.", "details": {}}
+        }), 404
+
+    snap = db["snapshots"].find_one({"_id": oid})
+    if not snap:
+        return jsonify({
+            "error": {"code": "SNAPSHOT_NOT_FOUND", "message": "스냅샷을 찾을 수 없습니다.", "details": {}}
+        }), 404
+
+    if str(snap["board_owner_id"]) != str(user_id):
+        return jsonify({
+            "error": {"code": "FORBIDDEN", "message": "스냅샷 소유자만 수정할 수 있습니다.", "details": {}}
+        }), 403
+
+    data = request.get_json(silent=True) or {}
+    new_is_public = data.get("is_public")
+    if new_is_public is None:
+        # 토글: 현재 값의 반대
+        new_is_public = not snap.get("is_public", False)
+
+    db["snapshots"].update_one({"_id": oid}, {"$set": {"is_public": bool(new_is_public)}})
+    return jsonify({"id": str(oid), "is_public": new_is_public}), 200

--- a/sockets.py
+++ b/sockets.py
@@ -1,6 +1,6 @@
 # sockets.py
 from flask import request
-from flask_socketio import ConnectionRefusedError, join_room
+from flask_socketio import ConnectionRefusedError, join_room, emit
 from flask_jwt_extended import decode_token
 from extensions import socketio
 
@@ -31,3 +31,11 @@ def on_join_board(data):
         room_name = f"board_{public_id}"
         join_room(room_name)
         print(f"[{room_name}] 방에 유저가 입장했습니다.")
+
+@socketio.on('move_note')
+def on_move_note(data):
+    public_id = data.get('public_id')
+    if public_id:
+        room_name = f"board_{public_id}"
+
+        emit('note_moved', data, room=room_name, include_self=False)

--- a/static/js/board.js
+++ b/static/js/board.js
@@ -14,12 +14,55 @@ $(document).ready(function () {
   let imageInsertMode = false;
   let pendingImagePosition = null;
 
+  const socket = io('/', {
+    withCredentials: true,
+  });
+
+  socket.on('connect', function () {
+    console.log('웹소켓 서버에 연결되었습니다!');
+
+    socket.emit('join_board', { public_id: publicId });
+  });
+
+  socket.on('connect_error', function (err) {
+    console.error('웹소켓 연결 실패 (인증 오류 등):', err.message);
+  });
+
+  socket.on('disconnect', function () {
+    console.log('웹소켓 연결이 끊어졌습니다.');
+  });
+
+  socket.on('note_moved', function (data) {
+    if (dragging.noteId !== String(data.note_id)) {
+      const $note = $container.find(`.note[data-note-id="${data.note_id}"]`);
+
+      if ($note.length) {
+        $note.animate(
+          {
+            left: data.x + 'px',
+            top: data.y + 'px',
+          },
+          300,
+        );
+
+        const noteObj = notes.find(
+          (n) => String(n.id) === String(data.note_id),
+        );
+        if (noteObj) {
+          noteObj.x = data.x;
+          noteObj.y = data.y;
+        }
+      }
+    }
+  });
+
   function loadBoard() {
     fetch(`/api/boards/${publicId}`, { credentials: 'include' })
       .then(async (res) => {
         const data = await res.json().catch(() => ({}));
         if (!res.ok) {
-          if (res.status === 404) throw new Error('유효하지 않은 보드 링크입니다.');
+          if (res.status === 404)
+            throw new Error('유효하지 않은 보드 링크입니다.');
           throw new Error(data?.error?.message || '보드를 불러올 수 없습니다.');
         }
         return data;
@@ -45,7 +88,9 @@ $(document).ready(function () {
       return;
     }
 
-    const myNotes = notes.filter((n) => String(n.owner_user_id) === String(currentUserId));
+    const myNotes = notes.filter(
+      (n) => String(n.owner_user_id) === String(currentUserId),
+    );
 
     if (myNotes.length === 0) {
       $empty.text('쓴 메모가 없습니다.').show();
@@ -70,8 +115,12 @@ $(document).ready(function () {
     $container.find('.note').removeClass('is-highlighted');
     $('#wingbar-my-notes .wingbar-note-item').removeClass('is-active');
     if (noteId) {
-      $container.find('.note[data-note-id="' + noteId + '"]').addClass('is-highlighted');
-      $('#wingbar-my-notes .wingbar-note-item[data-note-id="' + noteId + '"]').addClass('is-active');
+      $container
+        .find('.note[data-note-id="' + noteId + '"]')
+        .addClass('is-highlighted');
+      $(
+        '#wingbar-my-notes .wingbar-note-item[data-note-id="' + noteId + '"]',
+      ).addClass('is-active');
     }
   }
 
@@ -133,24 +182,99 @@ $(document).ready(function () {
     if (isBoardOwner) openBoardTitleModal();
   });
 
-  function updateNotePosition(noteId, x, y, version) {
-    const note = notes.find((n) => n.id === noteId);
-    if (!note) return;
-    fetch(`/api/boards/${publicId}/notes/${noteId}`, {
+  function openBoardTitleModal() {
+    $('#board-title-input').val(board?.title || '');
+    $('#board-title-modal').addClass('is-open').attr('aria-hidden', 'false');
+    setTimeout(() => $('#board-title-input').focus(), 100);
+  }
+  function closeBoardTitleModal() {
+    $('#board-title-modal').removeClass('is-open').attr('aria-hidden', 'true');
+  }
+  $(document).on(
+    'click',
+    '#board-title-modal .note-modal-backdrop[data-close="true"]',
+    closeBoardTitleModal,
+  );
+  $('#board-title-cancel').on('click', closeBoardTitleModal);
+  $('#board-title-save').on('click', function () {
+    const title = String($('#board-title-input').val() || '').trim();
+    fetch(`/api/boards/${publicId}`, {
       method: 'PATCH',
       credentials: 'include',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ version: note.version, x: Math.round(x), y: Math.round(y) }),
+      body: JSON.stringify({ title: title || '' }),
     })
       .then(async (res) => {
         if (res.status === 401) {
           showLoginRequiredModal();
           return null;
         }
+        if (res.status === 403) {
+          alert('보드 생성자만 제목을 수정할 수 있습니다.');
+          return null;
+        }
+        if (!res.ok) {
+          const d = await res.json().catch(() => ({}));
+          throw new Error(d?.error?.message || '수정 실패');
+        }
+        return res.json();
+      })
+      .then((data) => {
+        if (data && data.title !== undefined) {
+          board = board || {};
+          board.title = data.title;
+          $('#board-title').text(data.title || '보드 제목');
+          closeBoardTitleModal();
+          alert('보드 제목이 저장되었습니다.');
+        }
+      })
+      .catch((err) => alert(err.message));
+  });
+
+  $(document).on('click', '#board-title', function () {
+    const isBoardOwner = !!(
+      currentUserId &&
+      board &&
+      String(board.owner_user_id) === String(currentUserId)
+    );
+    if (isBoardOwner) openBoardTitleModal();
+  });
+
+  function updateNotePosition(noteId, x, y, version) {
+    const note = notes.find((n) => n.id === noteId);
+    if (!note) return;
+
+    const previousX = note.x;
+    const previousY = note.y;
+
+    note.x = x;
+    note.y = y;
+
+    fetch(`/api/boards/${publicId}/notes/${noteId}`, {
+      method: 'PATCH',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        version: note.version,
+        x: Math.round(x),
+        y: Math.round(y),
+      }),
+    })
+      .then(async (res) => {
+        if (res.status === 401) {
+          showLoginRequiredModal();
+          note.x = previousX;
+          note.y = previousY;
+          renderNotes();
+          return null;
+        }
         if (res.status === 403 || res.status === 409) {
           const data = await res.json().catch(() => ({}));
           loadBoard();
-          alert(data?.error?.message || '이동할 수 없습니다. 최신 상태로 새로고침했습니다.');
+          alert(
+            data?.error?.message ||
+              '이동할 수 없습니다. 최신 상태로 새로고침했습니다.',
+          );
           return null;
         }
         if (!res.ok) return null;
@@ -162,9 +286,19 @@ $(document).ready(function () {
           if (idx >= 0) notes[idx] = updated;
           renderNotes();
           renderWingbarMyNotes();
+
+          socket.emit('move_note', {
+            public_id: publicId,
+            note_id: noteId,
+            x: x,
+            y: y,
+          });
         }
       })
-      .catch(() => {});
+      .catch(() => {
+        note.x = previousX;
+        note.y = previousY;
+      });
   }
 
   function renderNotes() {
@@ -184,12 +318,19 @@ $(document).ready(function () {
       const $body = $('<div>').addClass('note-body');
       if (note.image_url) {
         $body.append(
-          $('<img>')
-            .attr('src', note.image_url)
-            .css({ maxWidth: '100%', display: 'block', marginBottom: 4, borderRadius: 4 })
+          $('<img>').attr('src', note.image_url).css({
+            maxWidth: '100%',
+            display: 'block',
+            marginBottom: 4,
+            borderRadius: 4,
+          }),
         );
       }
-      $body.append($('<div>').addClass('note-text').text(note.text || ''));
+      $body.append(
+        $('<div>')
+          .addClass('note-text')
+          .text(note.text || ''),
+      );
       $el.append($body);
 
       $container.append($el);
@@ -213,7 +354,9 @@ $(document).ready(function () {
         }
         if (!res.ok) {
           const data = await res.json().catch(() => ({}));
-          throw new Error(data?.error?.message || '포스트잇 생성에 실패했습니다.');
+          throw new Error(
+            data?.error?.message || '포스트잇 생성에 실패했습니다.',
+          );
         }
         return res.json();
       })
@@ -264,10 +407,14 @@ $(document).ready(function () {
 
   // 윙바
   function openWingbar() {
-    $('#wingbar-backdrop, #wingbar').addClass('is-open').attr('aria-hidden', 'false');
+    $('#wingbar-backdrop, #wingbar')
+      .addClass('is-open')
+      .attr('aria-hidden', 'false');
   }
   function closeWingbar() {
-    $('#wingbar-backdrop, #wingbar').removeClass('is-open').attr('aria-hidden', 'true');
+    $('#wingbar-backdrop, #wingbar')
+      .removeClass('is-open')
+      .attr('aria-hidden', 'true');
   }
   $('#btn-menu').on('click', openWingbar);
   $('#btn-close-wingbar').on('click', function () {
@@ -365,7 +512,11 @@ $(document).ready(function () {
   $('#btn-add-note').on('click', function () {
     openNoteModal(null);
   });
-  $(document).on('click', '.note-modal-backdrop[data-close="true"]', closeNoteModal);
+  $(document).on(
+    'click',
+    '.note-modal-backdrop[data-close="true"]',
+    closeNoteModal,
+  );
   $('#note-modal-cancel').on('click', closeNoteModal);
 
   $(document).on('click', '#note-modal-confirm', function (e) {
@@ -414,7 +565,13 @@ $(document).ready(function () {
   function tryOpenNoteModalAt(clientX, clientY) {
     if (imageInsertMode) return;
     const rect = $container[0].getBoundingClientRect();
-    if (clientX < rect.left || clientX > rect.right || clientY < rect.top || clientY > rect.bottom) return false;
+    if (
+      clientX < rect.left ||
+      clientX > rect.right ||
+      clientY < rect.top ||
+      clientY > rect.bottom
+    )
+      return false;
     const x = Math.max(20, clientX - rect.left);
     const y = Math.max(20, clientY - rect.top);
     openNoteModal({ x, y });
@@ -425,11 +582,26 @@ $(document).ready(function () {
     'mousedown',
     function (e) {
       if (e.button !== 0) return;
-      if ($(e.target).closest('.note, .note-modal, .note-detail-modal, .image-modal, .wingbar').length) return;
+      if (
+        $(e.target).closest(
+          '.note, .note-modal, .note-detail-modal, .image-modal, .wingbar',
+        ).length
+      )
+        return;
       const rect = $container[0].getBoundingClientRect();
-      if (e.clientX < rect.left || e.clientX > rect.right || e.clientY < rect.top || e.clientY > rect.bottom) return;
+      if (
+        e.clientX < rect.left ||
+        e.clientX > rect.right ||
+        e.clientY < rect.top ||
+        e.clientY > rect.bottom
+      )
+        return;
       const now = Date.now();
-      if (now - lastBoardMousedown.t <= DBLCLICK_DELAY && Math.abs(e.clientX - lastBoardMousedown.x) <= DBLCLICK_MOVE && Math.abs(e.clientY - lastBoardMousedown.y) <= DBLCLICK_MOVE) {
+      if (
+        now - lastBoardMousedown.t <= DBLCLICK_DELAY &&
+        Math.abs(e.clientX - lastBoardMousedown.x) <= DBLCLICK_MOVE &&
+        Math.abs(e.clientY - lastBoardMousedown.y) <= DBLCLICK_MOVE
+      ) {
         e.preventDefault();
         e.stopPropagation();
         lastBoardMousedown = { t: 0, x: 0, y: 0 };
@@ -438,19 +610,24 @@ $(document).ready(function () {
       }
       lastBoardMousedown = { t: now, x: e.clientX, y: e.clientY };
     },
-    true
+    true,
   );
 
   document.addEventListener(
     'dblclick',
     function (e) {
       if ($(e.target).closest('.note').length) return;
-      if ($(e.target).closest('.note-modal, .note-detail-modal, .image-modal, .wingbar').length) return;
+      if (
+        $(e.target).closest(
+          '.note-modal, .note-detail-modal, .image-modal, .wingbar',
+        ).length
+      )
+        return;
       if (tryOpenNoteModalAt(e.clientX, e.clientY)) {
         lastBoardMousedown = { t: 0, x: 0, y: 0 };
       }
     },
-    true
+    true,
   );
 
   // 포스트잇 더블클릭 → 수정 모달
@@ -463,7 +640,15 @@ $(document).ready(function () {
 
   // 포스트잇 드래그로 이동 (이동 8px 이상일 때만 드래그, 그 전에는 텍스트 선택 가능)
   const DRAG_THRESHOLD = 8;
-  let dragging = { $el: null, noteId: null, startX: 0, startY: 0, startLeft: 0, startTop: 0, active: false };
+  let dragging = {
+    $el: null,
+    noteId: null,
+    startX: 0,
+    startY: 0,
+    startLeft: 0,
+    startTop: 0,
+    active: false,
+  };
 
   // 포스트잇 상세 모달 (요구사항 4.4)
   let detailModalNoteId = null;
@@ -486,7 +671,9 @@ $(document).ready(function () {
     } else {
       $img.hide();
     }
-    const isOwner = !!(currentUserId && String(note.owner_user_id) === String(currentUserId));
+    const isOwner = !!(
+      currentUserId && String(note.owner_user_id) === String(currentUserId)
+    );
     if (isOwner) {
       $('#note-detail-edit, #note-detail-delete').show();
     } else {
@@ -499,7 +686,9 @@ $(document).ready(function () {
 
   function closeNoteDetailModal() {
     if (detailModalNoteId) {
-      const $noteEl = $container.find('.note[data-note-id="' + detailModalNoteId + '"]');
+      const $noteEl = $container.find(
+        '.note[data-note-id="' + detailModalNoteId + '"]',
+      );
       if ($noteEl.length && detailModalOriginalZ != null) {
         $noteEl.css('z-index', detailModalOriginalZ);
       }
@@ -510,7 +699,11 @@ $(document).ready(function () {
     $('#note-detail-modal').removeClass('is-open').attr('aria-hidden', 'true');
   }
 
-  $(document).on('click', '.note-detail-backdrop[data-close="true"]', closeNoteDetailModal);
+  $(document).on(
+    'click',
+    '.note-detail-backdrop[data-close="true"]',
+    closeNoteDetailModal,
+  );
   $('#note-detail-close').on('click', closeNoteDetailModal);
 
   $(document).on('keydown', function (e) {
@@ -553,7 +746,10 @@ $(document).ready(function () {
         if (res.status === 403 || res.status === 409) {
           const data = await res.json().catch(() => ({}));
           loadBoard();
-          alert(data?.error?.message || '수정할 수 없습니다. 최신 상태로 새로고침했습니다.');
+          alert(
+            data?.error?.message ||
+              '수정할 수 없습니다. 최신 상태로 새로고침했습니다.',
+          );
           closeNoteDetailModal();
           return null;
         }
@@ -576,7 +772,10 @@ $(document).ready(function () {
     if (!confirm('이 포스트잇을 삭제할까요?')) return;
     const noteId = detailModalNoteId;
     if (!noteId) return;
-    fetch(`/api/boards/${publicId}/notes/${noteId}`, { method: 'DELETE', credentials: 'include' })
+    fetch(`/api/boards/${publicId}/notes/${noteId}`, {
+      method: 'DELETE',
+      credentials: 'include',
+    })
       .then(async (res) => {
         if (res.status === 401) {
           showLoginRequiredModal();
@@ -629,12 +828,18 @@ $(document).ready(function () {
   $(document)
     .on('mousemove', function (e) {
       if (!dragging.$el) return;
+
       const dx = e.clientX - dragging.startX;
       const dy = e.clientY - dragging.startY;
-      if (!dragging.active && (Math.abs(dx) > DRAG_THRESHOLD || Math.abs(dy) > DRAG_THRESHOLD)) {
+      if (
+        !dragging.active &&
+        (Math.abs(dx) > DRAG_THRESHOLD || Math.abs(dy) > DRAG_THRESHOLD)
+      ) {
         dragging.active = true;
       }
+
       if (!dragging.active) return;
+
       dragging.$el.css({
         left: Math.max(0, dragging.startLeft + dx) + 'px',
         top: Math.max(0, dragging.startTop + dy) + 'px',
@@ -648,7 +853,15 @@ $(document).ready(function () {
         const top = parseFloat(dragging.$el.css('top')) || 0;
         updateNotePosition(dragging.noteId, left, top);
       }
-      dragging = { $el: null, noteId: null, startX: 0, startY: 0, startLeft: 0, startTop: 0, active: false };
+      dragging = {
+        $el: null,
+        noteId: null,
+        startX: 0,
+        startY: 0,
+        startLeft: 0,
+        startTop: 0,
+        active: false,
+      };
     });
 
   // 보드 클릭 (이미지 모드만) → 이미지 삽입 UI
@@ -671,7 +884,11 @@ $(document).ready(function () {
     pendingImagePosition = null;
   }
 
-  $(document).on('click', '.image-modal-backdrop[data-close="true"]', closeImageModal);
+  $(document).on(
+    'click',
+    '.image-modal-backdrop[data-close="true"]',
+    closeImageModal,
+  );
   $('#image-modal-cancel').on('click', closeImageModal);
 
   $('#image-modal-confirm').on('click', function () {
@@ -700,7 +917,9 @@ $(document).ready(function () {
         }
         if (!res.ok) {
           const data = await res.json().catch(() => ({}));
-          throw new Error(data?.error?.message || '이미지 업로드에 실패했습니다.');
+          throw new Error(
+            data?.error?.message || '이미지 업로드에 실패했습니다.',
+          );
         }
         return res.json();
       })

--- a/templates/board.html
+++ b/templates/board.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>크래프톤 정글 - 보드</title>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script src="https://cdn.socket.io/4.8.3/socket.io.min.js"></script>
     <style>
       .bg-logo {
         position: relative;
@@ -43,7 +44,7 @@
       .note-drag-handle::before {
         content: '⋮⋮';
         font-size: 12px;
-        color: rgba(0,0,0,0.3);
+        color: rgba(0, 0, 0, 0.3);
         padding-left: 4px;
       }
       .note-body {
@@ -76,7 +77,10 @@
       .header-pointer-through .header-clickable {
         pointer-events: auto;
       }
-      .select-none { user-select: none; -webkit-user-select: none; }
+      .select-none {
+        user-select: none;
+        -webkit-user-select: none;
+      }
       .wingbar-backdrop {
         position: fixed;
         inset: 0;
@@ -85,7 +89,9 @@
         opacity: 0;
         visibility: hidden;
         pointer-events: none;
-        transition: opacity 0.2s, visibility 0.2s;
+        transition:
+          opacity 0.2s,
+          visibility 0.2s;
       }
       .wingbar-backdrop.is-open {
         opacity: 1;
@@ -133,7 +139,9 @@
         color: #6b7280;
         cursor: pointer;
         border-radius: 6px;
-        transition: background 0.2s, color 0.2s;
+        transition:
+          background 0.2s,
+          color 0.2s;
       }
       .wingbar-close:hover {
         background: #f3f4f6;
@@ -156,7 +164,9 @@
         font-size: 15px;
         text-decoration: none;
         border-radius: 8px;
-        transition: background 0.2s, color 0.2s;
+        transition:
+          background 0.2s,
+          color 0.2s;
       }
       .wingbar-item:hover {
         background: #f3f4f6;
@@ -229,7 +239,9 @@
         opacity: 0;
         visibility: hidden;
         pointer-events: none;
-        transition: opacity 0.2s, visibility 0.2s;
+        transition:
+          opacity 0.2s,
+          visibility 0.2s;
       }
       .image-modal.is-open {
         opacity: 1;
@@ -239,7 +251,7 @@
       .image-modal-backdrop {
         position: absolute;
         inset: 0;
-        background: rgba(0,0,0,0.4);
+        background: rgba(0, 0, 0, 0.4);
       }
       .image-modal-panel {
         position: relative;
@@ -248,7 +260,7 @@
         padding: 24px;
         background: white;
         border-radius: 12px;
-        box-shadow: 0 10px 40px rgba(0,0,0,0.2);
+        box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
       }
       .image-modal-title {
         margin: 0 0 16px;
@@ -282,11 +294,11 @@
         color: #374151;
       }
       .image-modal-btn-primary {
-        background: #05D182;
+        background: #05d182;
         color: white;
       }
       #btn-add-image.image-mode-active {
-        outline: 2px solid #05D182;
+        outline: 2px solid #05d182;
         outline-offset: 2px;
       }
       /* 새 포스트잇 모달 */
@@ -300,7 +312,9 @@
         opacity: 0;
         visibility: hidden;
         pointer-events: none;
-        transition: opacity 0.2s, visibility 0.2s;
+        transition:
+          opacity 0.2s,
+          visibility 0.2s;
       }
       .note-modal.is-open {
         opacity: 1;
@@ -310,7 +324,7 @@
       .note-modal-backdrop {
         position: absolute;
         inset: 0;
-        background: rgba(0,0,0,0.4);
+        background: rgba(0, 0, 0, 0.4);
       }
       .note-modal-panel {
         position: relative;
@@ -319,7 +333,7 @@
         padding: 24px;
         background: white;
         border-radius: 12px;
-        box-shadow: 0 10px 40px rgba(0,0,0,0.2);
+        box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
       }
       .note-modal-title {
         margin: 0 0 8px;
@@ -344,8 +358,8 @@
         outline: none;
       }
       .note-modal-textarea:focus {
-        border-color: #05D182;
-        box-shadow: 0 0 0 2px rgba(5,209,130,0.2);
+        border-color: #05d182;
+        box-shadow: 0 0 0 2px rgba(5, 209, 130, 0.2);
       }
       .note-modal-actions {
         display: flex;
@@ -365,7 +379,7 @@
         color: #374151;
       }
       .note-modal-btn-primary {
-        background: #05D182;
+        background: #05d182;
         color: white;
       }
       /* 포스트잇 상세 모달 (요구사항 4.4) */
@@ -379,7 +393,9 @@
         opacity: 0;
         visibility: hidden;
         pointer-events: none;
-        transition: opacity 0.2s, visibility 0.2s;
+        transition:
+          opacity 0.2s,
+          visibility 0.2s;
       }
       .note-detail-modal.is-open {
         opacity: 1;
@@ -389,7 +405,7 @@
       .note-detail-backdrop {
         position: absolute;
         inset: 0;
-        background: rgba(0,0,0,0.5);
+        background: rgba(0, 0, 0, 0.5);
       }
       .note-detail-panel {
         position: relative;
@@ -399,7 +415,7 @@
         padding: 24px;
         background: white;
         border-radius: 12px;
-        box-shadow: 0 10px 40px rgba(0,0,0,0.2);
+        box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
         overflow-y: auto;
       }
       .note-detail-text {
@@ -461,7 +477,11 @@
           />
         </button>
 
-        <button id="btn-add-image" class="hover:scale-110 transition transform" title="이미지 추가 모드 (클릭 후 보드에서 위치 선택)">
+        <button
+          id="btn-add-image"
+          class="hover:scale-110 transition transform"
+          title="이미지 추가 모드 (클릭 후 보드에서 위치 선택)"
+        >
           <img
             src="{{ url_for('static', filename='icons/image.svg') }}"
             alt="이미지 추가"
@@ -483,18 +503,32 @@
     <main
       id="board-container"
       class="fixed inset-0 min-w-full min-h-full bg-logo z-10 pt-24"
-      style="overflow:auto;"
+      style="overflow: auto"
       data-public-id="{{ public_id }}"
     >
-      <div id="board-click-layer" style="position:absolute;inset:0;z-index:0;cursor:default;"></div>
+      <div
+        id="board-click-layer"
+        style="position: absolute; inset: 0; z-index: 0; cursor: default"
+      ></div>
     </main>
 
     <!-- 우측 윙바 -->
-    <div class="wingbar-backdrop" id="wingbar-backdrop" aria-hidden="true"></div>
+    <div
+      class="wingbar-backdrop"
+      id="wingbar-backdrop"
+      aria-hidden="true"
+    ></div>
     <aside class="wingbar" id="wingbar" aria-hidden="true">
       <div class="wingbar-header">
         <span class="wingbar-title">메뉴</span>
-        <button type="button" id="btn-close-wingbar" class="wingbar-close" aria-label="닫기">×</button>
+        <button
+          type="button"
+          id="btn-close-wingbar"
+          class="wingbar-close"
+          aria-label="닫기"
+        >
+          ×
+        </button>
       </div>
       <div class="wingbar-body">
         <a href="/main" class="wingbar-item">
@@ -508,7 +542,13 @@
         <div class="wingbar-section">
           <h3 class="wingbar-section-title">내가 쓴 메모</h3>
           <ul class="wingbar-note-list" id="wingbar-my-notes"></ul>
-          <p class="wingbar-empty" id="wingbar-my-notes-empty" style="display:none;">쓴 메모가 없습니다.</p>
+          <p
+            class="wingbar-empty"
+            id="wingbar-my-notes-empty"
+            style="display: none"
+          >
+            쓴 메모가 없습니다.
+          </p>
         </div>
       </div>
     </aside>
@@ -547,8 +587,20 @@
         <p class="note-modal-hint">내용을 입력하고 추가를 누르면 마우스 커서 위치에 포스트잇이 생성됩니다.</p>
         <textarea id="note-modal-text" class="note-modal-textarea" placeholder="메모 내용을 입력하세요..." rows="4"></textarea>
         <div class="note-modal-actions">
-          <button type="button" id="note-modal-cancel" class="note-modal-btn note-modal-btn-secondary">취소</button>
-          <button type="button" id="note-modal-confirm" class="note-modal-btn note-modal-btn-primary">추가</button>
+          <button
+            type="button"
+            id="note-modal-cancel"
+            class="note-modal-btn note-modal-btn-secondary"
+          >
+            취소
+          </button>
+          <button
+            type="button"
+            id="note-modal-confirm"
+            class="note-modal-btn note-modal-btn-primary"
+          >
+            추가
+          </button>
         </div>
       </div>
     </div>
@@ -559,18 +611,59 @@
       <div class="note-detail-panel">
         <div id="note-detail-view">
           <p class="note-detail-text" id="note-detail-text"></p>
-          <img class="note-detail-image" id="note-detail-image" alt="" style="display:none;" />
+          <img
+            class="note-detail-image"
+            id="note-detail-image"
+            alt=""
+            style="display: none"
+          />
           <div class="note-detail-actions" id="note-detail-actions">
-            <button type="button" id="note-detail-edit" class="note-modal-btn note-modal-btn-secondary" style="display:none;">수정</button>
-            <button type="button" id="note-detail-delete" class="note-modal-btn note-modal-btn-secondary" style="display:none;">삭제</button>
-            <button type="button" id="note-detail-close" class="note-modal-btn note-modal-btn-primary">닫기</button>
+            <button
+              type="button"
+              id="note-detail-edit"
+              class="note-modal-btn note-modal-btn-secondary"
+              style="display: none"
+            >
+              수정
+            </button>
+            <button
+              type="button"
+              id="note-detail-delete"
+              class="note-modal-btn note-modal-btn-secondary"
+              style="display: none"
+            >
+              삭제
+            </button>
+            <button
+              type="button"
+              id="note-detail-close"
+              class="note-modal-btn note-modal-btn-primary"
+            >
+              닫기
+            </button>
           </div>
         </div>
-        <div id="note-detail-edit-view" style="display:none;">
-          <textarea id="note-detail-edit-textarea" class="note-detail-edit-textarea" placeholder="메모 내용"></textarea>
+        <div id="note-detail-edit-view" style="display: none">
+          <textarea
+            id="note-detail-edit-textarea"
+            class="note-detail-edit-textarea"
+            placeholder="메모 내용"
+          ></textarea>
           <div class="note-detail-actions">
-            <button type="button" id="note-detail-save" class="note-modal-btn note-modal-btn-primary">저장</button>
-            <button type="button" id="note-detail-cancel-edit" class="note-modal-btn note-modal-btn-secondary">취소</button>
+            <button
+              type="button"
+              id="note-detail-save"
+              class="note-modal-btn note-modal-btn-primary"
+            >
+              저장
+            </button>
+            <button
+              type="button"
+              id="note-detail-cancel-edit"
+              class="note-modal-btn note-modal-btn-secondary"
+            >
+              취소
+            </button>
           </div>
         </div>
       </div>
@@ -607,10 +700,27 @@
       <div class="image-modal-backdrop" data-close="true"></div>
       <div class="image-modal-panel">
         <h3 class="image-modal-title">이미지 추가</h3>
-        <input type="file" id="image-file-input" accept="image/jpeg,image/png,image/gif" class="image-modal-input" />
+        <input
+          type="file"
+          id="image-file-input"
+          accept="image/jpeg,image/png,image/gif"
+          class="image-modal-input"
+        />
         <div class="image-modal-actions">
-          <button type="button" id="image-modal-cancel" class="image-modal-btn image-modal-btn-secondary">취소</button>
-          <button type="button" id="image-modal-confirm" class="image-modal-btn image-modal-btn-primary">추가</button>
+          <button
+            type="button"
+            id="image-modal-cancel"
+            class="image-modal-btn image-modal-btn-secondary"
+          >
+            취소
+          </button>
+          <button
+            type="button"
+            id="image-modal-confirm"
+            class="image-modal-btn image-modal-btn-primary"
+          >
+            추가
+          </button>
         </div>
       </div>
     </div>

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -1,0 +1,204 @@
+"""
+스냅샷 API 테스트.
+"""
+import io
+
+import pytest
+
+from flask_jwt_extended import create_access_token
+
+# 1x1 픽셀 PNG (유효한 이미지 파일)
+MINIMAL_PNG_BYTES = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc\x00\x01"
+    b"\x00\x00\x05\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+
+class TestUploadSnapshot:
+    """POST /api/snapshots - 스냅샷 이미지 업로드"""
+
+    def test_비인증_401(self, client, board_with_public_id):
+        """인증 없이 업로드 시 401"""
+        public_id = board_with_public_id
+        data = {"file": (io.BytesIO(MINIMAL_PNG_BYTES), "test.png"), "board_public_id": public_id}
+        res = client.post("/api/snapshots", data=data)
+        assert res.status_code == 401
+        assert res.get_json()["error"]["code"] == "UNAUTHORIZED"
+
+    def test_board_public_id_누락_400(self, auth_client):
+        """board_public_id 없을 때 400"""
+        data = {"file": (io.BytesIO(MINIMAL_PNG_BYTES), "test.png")}
+        res = auth_client.post("/api/snapshots", data=data)
+        assert res.status_code == 400
+        assert "board_public_id" in res.get_json().get("error", {}).get("message", "")
+
+    def test_존재하지_않는_보드_404(self, auth_client):
+        """유효하지 않은 board_public_id 시 404"""
+        data = {
+            "file": (io.BytesIO(MINIMAL_PNG_BYTES), "test.png"),
+            "board_public_id": "00000000-0000-0000-0000-000000000000",
+        }
+        res = auth_client.post("/api/snapshots", data=data)
+        assert res.status_code == 404
+        assert res.get_json()["error"]["code"] == "BOARD_NOT_FOUND"
+
+    def test_보드_생성자_아님_403(self, client, board_with_public_id):
+        """다른 사용자 보드에 스냅샷 업로드 시 403"""
+        public_id = board_with_public_id  # auth_client가 소유한 보드
+        # 다른 사용자 생성
+        res = client.post("/api/auth/register", json={"username": "other_user_12345", "password": "testpass"})
+        assert res.status_code == 201
+        other_user_id = res.get_json()["user_id"]
+        token = create_access_token(identity=other_user_id)
+        headers = {"Authorization": f"Bearer {token}"}
+        data = {"file": (io.BytesIO(MINIMAL_PNG_BYTES), "test.png"), "board_public_id": public_id}
+        res = client.post("/api/snapshots", data=data, headers=headers)
+        assert res.status_code == 403
+        assert res.get_json()["error"]["code"] == "FORBIDDEN"
+
+    def test_파일_없음_400(self, auth_client, board_with_public_id):
+        """file 필드 없을 때 400"""
+        data = {"board_public_id": board_with_public_id}
+        res = auth_client.post("/api/snapshots", data=data)
+        assert res.status_code == 400
+
+    def test_업로드_성공_201(self, auth_client, board_with_public_id):
+        """유효한 이미지 업로드 시 201, image_key 반환"""
+        public_id = board_with_public_id
+        data = {"file": (io.BytesIO(MINIMAL_PNG_BYTES), "test.png"), "board_public_id": public_id}
+        res = auth_client.post("/api/snapshots", data=data)
+        assert res.status_code == 201
+        body = res.get_json()
+        assert "image_key" in body
+        assert body["image_key"].startswith("uploads/snapshots/")
+        assert body["image_key"].endswith(".png")
+
+
+class TestListMine:
+    """GET /api/snapshots/mine - 내 스냅샷 목록"""
+
+    def test_비인증_401(self, client):
+        """인증 없이 조회 시 401"""
+        res = client.get("/api/snapshots/mine")
+        assert res.status_code == 401
+
+    def test_빈_목록_200(self, auth_client):
+        """스냅샷 없을 때 200, 빈 배열"""
+        res = auth_client.get("/api/snapshots/mine")
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["snapshots"] == []
+        assert data["total"] == 0
+
+
+class TestListPublic:
+    """GET /api/snapshots/public - 공개 스냅샷 목록"""
+
+    def test_비인증_가능_200(self, client):
+        """인증 없이 조회 가능"""
+        res = client.get("/api/snapshots/public")
+        assert res.status_code == 200
+        data = res.get_json()
+        assert "snapshots" in data
+        assert "total" in data
+
+
+class TestGetSnapshotImage:
+    """GET /api/snapshots/{id}/image - 스냅샷 이미지 조회"""
+
+    def test_존재하지_않는_스냅샷_404(self, client):
+        """유효하지 않은 snapshot_id 시 404"""
+        res = client.get("/api/snapshots/000000000000000000000000/image")
+        assert res.status_code == 404
+
+
+class TestPatchSnapshot:
+    """PATCH /api/snapshots/{id} - 공개 여부 토글"""
+
+    def test_비인증_401(self, client):
+        """인증 없이 PATCH 시 401"""
+        res = client.patch("/api/snapshots/000000000000000000000000", json={"is_public": True})
+        assert res.status_code == 401
+
+
+class TestBoardDeleteWithSnapshot:
+    """보드 삭제 + image_key → 스냅샷 레코드 생성 및 목록/이미지 조회"""
+
+    def test_업로드_후_삭제_스냅샷_목록_조회(self, auth_client, board_with_public_id):
+        """스냅샷 업로드 → 보드 삭제(image_key 포함) → 내 스냅샷 목록에 노출"""
+        public_id = board_with_public_id
+        # 1. 스냅샷 이미지 업로드
+        upload_data = {
+            "file": (io.BytesIO(MINIMAL_PNG_BYTES), "snap.png"),
+            "board_public_id": public_id,
+        }
+        up = auth_client.post("/api/snapshots", data=upload_data)
+        assert up.status_code == 201
+        image_key = up.get_json()["image_key"]
+        # 2. 보드 삭제 (image_key 포함)
+        del_res = auth_client.delete(
+            f"/api/boards/{public_id}",
+            json={"image_key": image_key},
+            headers={"Content-Type": "application/json"},
+        )
+        assert del_res.status_code == 204
+        # 3. 내 스냅샷 목록
+        list_res = auth_client.get("/api/snapshots/mine")
+        assert list_res.status_code == 200
+        data = list_res.get_json()
+        assert data["total"] == 1
+        assert len(data["snapshots"]) == 1
+        snap = data["snapshots"][0]
+        assert "id" in snap
+        assert "image_url" in snap
+        assert snap["is_public"] is False
+        # 4. 이미지 조회
+        img_res = auth_client.get(snap["image_url"])
+        assert img_res.status_code == 200
+        assert img_res.content_type.startswith("image/")
+        assert img_res.data == MINIMAL_PNG_BYTES
+
+    def test_스냅샷_공개_토글_후_비인증_조회(self, client, auth_client, board_with_public_id):
+        """스냅샷 공개 전환 후 비인증 사용자도 이미지 조회 가능"""
+        public_id = board_with_public_id
+        upload_data = {
+            "file": (io.BytesIO(MINIMAL_PNG_BYTES), "snap.png"),
+            "board_public_id": public_id,
+        }
+        up = auth_client.post("/api/snapshots", data=upload_data)
+        assert up.status_code == 201
+        image_key = up.get_json()["image_key"]
+        auth_client.delete(f"/api/boards/{public_id}", json={"image_key": image_key})
+        list_res = auth_client.get("/api/snapshots/mine")
+        snapshot_id = list_res.get_json()["snapshots"][0]["id"]
+        # PATCH로 공개 전환
+        patch_res = auth_client.patch(f"/api/snapshots/{snapshot_id}", json={"is_public": True})
+        assert patch_res.status_code == 200
+        # 비인증 client로 이미지 조회
+        img_res = client.get(f"/api/snapshots/{snapshot_id}/image")
+        assert img_res.status_code == 200
+        assert img_res.data == MINIMAL_PNG_BYTES
+
+    def test_비공개_스냅샷_타인_조회_403(self, client, auth_client, board_with_public_id):
+        """비공개 스냅샷을 소유자가 아닌 사용자가 조회 시 403"""
+        public_id = board_with_public_id
+        upload_data = {
+            "file": (io.BytesIO(MINIMAL_PNG_BYTES), "snap.png"),
+            "board_public_id": public_id,
+        }
+        up = auth_client.post("/api/snapshots", data=upload_data)
+        assert up.status_code == 201
+        image_key = up.get_json()["image_key"]
+        auth_client.delete(f"/api/boards/{public_id}", json={"image_key": image_key})
+        list_res = auth_client.get("/api/snapshots/mine")
+        snapshot_id = list_res.get_json()["snapshots"][0]["id"]
+        # 다른 사용자로 이미지 조회 시도
+        other = client.post("/api/auth/register", json={"username": "other_snap_12345", "password": "test"})
+        assert other.status_code == 201
+        token = create_access_token(identity=other.get_json()["user_id"])
+        img_res = client.get(
+            f"/api/snapshots/{snapshot_id}/image",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert img_res.status_code == 403


### PR DESCRIPTION
# 요약
- Closes #45 - 보드 삭제 시 클라이언트 캡처 → 스냅샷 이미지 저장 → 보드 주인 귀속
- API 명세서(v2)에 스냅샷 관련 누락사항이 있어 수정하였습니다.
*스냅샷 게시판에 필요한 api 초안도 추가해두었습니다.

# 주요 변경사항
- POST /api/snapshots - 스냅샷 이미지 업로드 API
- GET /api/snapshots/mine, /public, /{id}/image
- PATCH /api/snapshots/{id} - 공개 여부 토글
- DELETE /api/boards/{public_id} - Request Body image_key 지원
- 스냅샷 API 테스트 추가
